### PR TITLE
ci: test against WP 6.3 + PHP 8.1

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup PHP w/ Composer & WP-CLI
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
+          php-version: 8.1
           extensions: mbstring, intl, bcmath, exif, gd, mysqli, opcache, zip, pdo_mysql
           tools: composer:v2, wp-cli
           coverage: none

--- a/.github/workflows/code-standard.yml
+++ b/.github/workflows/code-standard.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
+          php-version: 8.1
           tools: composer:v2
           coverage: none
 

--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -23,11 +23,11 @@ jobs:
 
     strategy:
       matrix:
-        php: [ '8.0', '7.4' ]
-        wordpress: [ '6.2', '6.1', '6.0', '5.9' ]
+        php: [ '8.1', '8.0', '7.4' ]
+        wordpress: [ '6.3', '6.2', '6.1', '6.0', '5.9' ]
         include:
           - php: '8.1'
-            wordpress: '6.2'
+            wordpress: '6.3'
             coverage: 1
           # Older versions of WordPress
           - php: '8.0'
@@ -39,6 +39,8 @@ jobs:
           - php: '7.4'
             wordpress: '5.7'
         exclude:
+          - php: '7.4'
+            wordpress: '6.3'
           - php: '7.4'
             wordpress: '6.2'
       fail-fast: false

--- a/.github/workflows/schema-linter.yml
+++ b/.github/workflows/schema-linter.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup PHP w/ Composer & WP-CLI
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
+          php-version: 8.1
           extensions: mbstring, intl, bcmath, exif, gd, mysqli, opcache, zip, pdo_mysql
           coverage: none
           tools: composer:v2, wp-cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - chore: Update Composer dev-deps.
 - tests: Set `WPLoader.loadOnly` to true for acceptance suite. Thanks @lucatume!
 - ci: Fix GitHub Action workflows by locking MariaDB version to v10.
+- ci: Test against WordPress 6.3 and PHP 8.1
 
 ## v0.12.2
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Our hope for this open source project is that it will enable more teams to lever
 
 ## System Requirements
 
-* PHP 7.4+ || 8.0
+* PHP 7.4+
 * WordPress 5.4.1+
 * WPGraphQL 1.9.0+
 * Gravity Forms 2.5+ (Recommend: v2.6+)

--- a/bin/run-docker.sh
+++ b/bin/run-docker.sh
@@ -16,11 +16,11 @@ print_usage_instructions() {
 	echo "  composer build-app"
 	echo "  composer run-app"
 	echo ""
-	echo "  WP_VERSION=6.2 PHP_VERSION=8.0 composer build-app"
-	echo "  WP_VERSION=6.2 PHP_VERSION=8.0 composer run-app"
+	echo "  WP_VERSION=6.3 PHP_VERSION=8.1 composer build-app"
+	echo "  WP_VERSION=6.3 PHP_VERSION=8.1 composer run-app"
 	echo ""
-	echo "  WP_VERSION=6.2 PHP_VERSION=8.0 bin/run-docker.sh build -a"
-	echo "  WP_VERSION=6.2 PHP_VERSION=8.0 bin/run-docker.sh run -a"
+	echo "  WP_VERSION=6.3 PHP_VERSION=8.1 bin/run-docker.sh build -a"
+	echo "  WP_VERSION=6.3 PHP_VERSION=8.1 bin/run-docker.sh run -a"
 	exit 1
 }
 
@@ -29,8 +29,8 @@ if [ $# -eq 0 ]; then
 fi
 
 TAG=${TAG-latest}
-WP_VERSION=${WP_VERSION-6.2}
-PHP_VERSION=${PHP_VERSION-8.0}
+WP_VERSION=${WP_VERSION-6.3}
+PHP_VERSION=${PHP_VERSION-8.1}
 
 BUILD_NO_CACHE=${BUILD_NO_CACHE-}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   app:
     depends_on:
       - app_db
-    image: wp-graphql-gravity-forms:latest-wp${WP_VERSION-6.2}-php${PHP_VERSION-8.0}
+    image: wp-graphql-gravity-forms:latest-wp${WP_VERSION-6.3}-php${PHP_VERSION-8.1}
     volumes:
       - .:/var/www/html/wp-content/plugins/wp-graphql-gravity-forms
       - ./.log/app:/var/log/apache2

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: justlevine, kellenmace, mtdbyanechko, tinytoolbox
 Tags: Forms, GraphQL, Gatsby, Headless, GF, Gravity, WPGraphQL, React
 Requires at least: 5.4.1
-Tested up to: 6.2.2
+Tested up to: 6.3.1
 Requires PHP: 7.4
 Requires Gravity Forms: 2.5.0
 Requires WPGraphQL: 1.9.0

--- a/wp-graphql-gravity-forms.php
+++ b/wp-graphql-gravity-forms.php
@@ -11,7 +11,7 @@
  * Text Domain: wp-graphql-gravity-forms
  * Domain Path: /languages
  * Requires at least: 5.4.1
- * Tested up to: 6.2.2
+ * Tested up to: 6.3.1
  * Requires PHP: 7.4
  * WPGraphQL requires at least: 1.9.0
  * GravityForms requires at least: 2.5.0


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
Changes the ci actions, testing matrix, and plugin headers to support WordPress 6.3.1 and PHP 8.1.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
