### PR TITLE
ci: only run PHP 8.1 against WP 6.2+

### DIFF
--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -23,21 +23,14 @@ jobs:
 
     strategy:
       matrix:
-        php: [ '8.1', '8.0', '7.4' ]
-        wordpress: [ '6.3', '6.2', '6.1', '6.0', '5.9' ]
+        php: [ '8.0', '7.4' ]
+        wordpress: [ '6.3', '6.2', '6.1', '6.0', '5.9', '5.8', '5.7' ]
         include:
           - php: '8.1'
             wordpress: '6.3'
             coverage: 1
-          # Older versions of WordPress
-          - php: '8.0'
-            wordpress: '5.8'
-          - php: '8.0'
-            wordpress: '5.7'
-          - php: '7.4'
-            wordpress: '5.8'
-          - php: '7.4'
-            wordpress: '5.7'
+          - php: '8.1'
+            wordpress: '6.2'
         exclude:
           - php: '7.4'
             wordpress: '6.3'


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

Limits CI testing matrix to only test PHP 8.1 on WordPress versions 6.2+ (since GF + WP is not compatible with earlier versions).

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
