### PR TITLE
fix: Pass the GF entry to the `QuizResults` resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - fix: Check if entries exist before resolving the connection `count`.
 - fix: Improve type checks when calculating the `QuizResults` data.
+- fix: Pass the entry array to the `QuizResults` resolver.
 - chore: Fix Composer PHP version constraints and rebuild lockfile. Thanks @szepeviktor!
 - chore: Update WPGraphQL Coding Standards to 2.0.0-beta.1 and fix resulting issues.
 - chore: Update Composer dev-deps.

--- a/src/Extensions/GFQuiz/Type/WPObject/Entry/EntryQuizResults.php
+++ b/src/Extensions/GFQuiz/Type/WPObject/Entry/EntryQuizResults.php
@@ -93,7 +93,7 @@ class EntryQuizResults extends AbstractObject implements Field {
 				'type'        => static::$type,
 				'description' => __( 'The quiz results for the entry. Requires Gravity Forms Quiz to be enabled.', 'wp-graphql-gravity-forms' ),
 				'resolve'     => static function ( $source ) {
-					return $source;
+					return ! empty( $source->entry ) ? $source->entry : null;
 				},
 			]
 		);


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
Passes the GF entry array to the `QuizResults` resolver, instead of the `SubmittedEntry` object.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
`SubmittedEntry` doesnt include the quiz results.

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
