### PR TITLE
fix: ensure `EmailField` inputs are hydrated when Email Confirmation is disabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- fix: Ensure `EmailField` inputs are hydrated when Email Confirmation is disabled. H/t @
+Gytjarek.
+
 ## v0.12.4
 
 This _minor_ release fixes a bug where updating the plugin via the WordPress backend would fail due to changes to GitHub's API.

--- a/src/Type/WPInterface/FieldWithInputs.php
+++ b/src/Type/WPInterface/FieldWithInputs.php
@@ -37,11 +37,26 @@ class FieldWithInputs extends AbstractInterface {
 			'inputs' => [
 				'type'        => [ 'list_of' => FieldInput::$type ],
 				'description' => __( 'The inputs for the field.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static function ( $source, array $args, AppContext $context, $info ) {
+				'resolve'     => static function ( $source, array $args, AppContext $context ) {
+					// Email fields without confirmation need to be coerced as an input.
+					if ( $source instanceof \GF_Field_Email && ! $source->emailConfirmEnabled ) {
+						$source->inputs = [
+							[
+								'autocompleteAttribute' => $source->autocompleteAttribute ?? null,
+								'defaultValue'          => $source->defaultValue ?? null,
+								'customLabel'           => $source->customLabel ?? null,
+								'id'                    => $source->id ?? null,
+								'label'                 => $source->label ?? null,
+								'name'                  => $source->inputName ?? null,
+								'placeholder'           => $source->placeholder ?? null,
+							],
+						];
+					}
+
 					/** @var \GF_Field $source */
 					$context->gfField = $source;
 
-					return ! empty( $source->inputs )
+					return isset( $source->inputs )
 						// Include GraphQL Type in resolver.
 						? array_map(
 							static function ( $choice ) use ( $source ) {


### PR DESCRIPTION

<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR fixes `formField.input` returning `null` for `EmailField` types that have Email Confirmation disabled.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
Closes #392 

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->
`GF_Field_Email` only uses the `inputs` property for fields with Email Confirmation, so we're manually populating the array with "Default" values.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->


## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

The `autocompleteAttribute` field is not saving in GF v2.8.x. Reported upstream. When assigned programmatically, the response works.

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
