### PR TITLE
fix: correctly use filtered form fields when preparing the connection data.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 ## Unreleased
 
 - fix: Ensure `EmailField` inputs are hydrated when Email Confirmation is disabled. H/t @gytjarek.
+- fix: Correctly use filtered form fields when preparing the connection data. H/t @samuelhadsall.
 - chore: Update `yahnis-elsts/plugin-update-checker` to v5.3.
 - chore: Update `axepress/wp-graphql-cs` to v2.0.0-beta.2 and fix resulting issues.
 - chore: Update Composer dev deps.
-- chore: Test compatibility with WordPress 6.4.x
+- ci: Test compatibility with WordPress 6.4.x
 - docs: Add docs on troubleshooting i18n issues. H/t @dev-ditrict-web.
 
 ## v0.12.4

--- a/src/Data/Connection/FormFieldsConnectionResolver.php
+++ b/src/Data/Connection/FormFieldsConnectionResolver.php
@@ -86,7 +86,7 @@ class FormFieldsConnectionResolver {
 
 		$fields = self::filter_form_fields_by_connection_args( $source, $args );
 
-		$fields = self::prepare_data( $source );
+		$fields = self::prepare_data( $fields );
 
 		$connection = Relay::connectionFromArray( $fields, $args );
 
@@ -172,7 +172,7 @@ class FormFieldsConnectionResolver {
 		if ( isset( $args['where']['pageNumber'] ) ) {
 			$page = absint( $args['where']['pageNumber'] );
 
-			$fields = array_filter( $fields, static fn ( $field ) => $page === (int) $field['pageNumber'] );
+			$fields = array_filter( $fields, static fn ( $field ) => $page === (int) $field->pageNumber );
 		}
 
 		return $fields;

--- a/tests/wpunit/CaptchaFieldTest.php
+++ b/tests/wpunit/CaptchaFieldTest.php
@@ -116,7 +116,7 @@ class CaptchaFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 		return "
 			query getFieldValue(\$id: ID!, \$idType: EntryIdTypeEnum) {
 				gfEntry(id: \$id, idType: \$idType ) {
-					formFields(where:{fieldTypes:CAPTCHA}) {
+					formFields {
 						nodes {
 							{$this->field_query}
 						}


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR fixes the `FormFieldConnectionResolver` so the form fields filtered by the connection `where` args are used, instead of the pre-filtered values.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

Closes #392 

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
