### PR TITLE
chore: fix phpcompatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- feat: Add plugin dependency header.
 - chore: update Composer deps and lint.
 - chore: lock WPBrowser to <3.5.0 to prevent conflicts with Codeception.
 - ci: Update GitHub Actions to latest versions.

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
 		"axepress/wp-graphql-cs": "^2.0.0-beta",
 		"wp-cli/wp-cli-bundle": "^2.8.1",
 		"php-coveralls/php-coveralls": "^2.5",
-		"phpcompatibility/php-compatibility": "dev-master as 9.99.99"
+		"phpcompatibility/php-compatibility": "dev-develop as 9.99.99"
 	},
 	"config": {
 		"optimize-autoloader": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2023122e7884504096cea3c418b4ed5d",
+    "content-hash": "d9bb9181bc10b3c01df3856b8caa788e",
     "packages": [
         {
             "name": "yahnis-elsts/plugin-update-checker",
@@ -3814,33 +3814,45 @@
         },
         {
             "name": "phpcompatibility/php-compatibility",
-            "version": "dev-master",
+            "version": "dev-develop",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
+                "reference": "88e77dff171bdd843969a4297ebe52f9f849275a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
-                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/88e77dff171bdd843969a4297ebe52f9f849275a",
+                "reference": "88e77dff171bdd843969a4297ebe52f9f849275a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.0.9",
+                "squizlabs/php_codesniffer": "^3.9.0"
             },
-            "conflict": {
-                "squizlabs/php_codesniffer": "2.6.2"
+            "replace": {
+                "wimg/php-compatibility": "*"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.3",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4 || ^10.1.0",
+                "yoast/phpunit-polyfills": "^1.0.5 || ^2.0.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
+            "default-branch": true,
             "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.x-dev",
+                    "dev-develop": "10.x-dev"
+                }
+            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "LGPL-3.0-or-later"
@@ -3866,13 +3878,29 @@
             "keywords": [
                 "compatibility",
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
+                "security": "https://github.com/PHPCompatibility/PHPCompatibility/security/policy",
                 "source": "https://github.com/PHPCompatibility/PHPCompatibility"
             },
-            "time": "2019-12-27T09:44:58+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCompatibility",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-04-02T20:53:47+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
@@ -11048,7 +11076,7 @@
     "aliases": [
         {
             "package": "phpcompatibility/php-compatibility",
-            "version": "9999999-dev",
+            "version": "dev-develop",
             "alias": "9.99.99",
             "alias_normalized": "9.99.99.0"
         }

--- a/src/Interfaces/Enum.php
+++ b/src/Interfaces/Enum.php
@@ -11,6 +11,7 @@ namespace WPGraphQL\GF\Interfaces;
 /**
  * Interface - Enum.
  */
+// phpcs:ignore PHPCompatibility.Keywords.ForbiddenNames.enumFound -- @todo Remove b/c
 interface Enum {
 	/**
 	 * Gets the Enum type values.

--- a/src/Registry/FormFieldRegistry.php
+++ b/src/Registry/FormFieldRegistry.php
@@ -134,12 +134,14 @@ class FormFieldRegistry {
 		}
 
 		// We flip the arrays and compare the keys for performance.
-		$interface_settings = array_keys(
-			array_intersect_key(
-				...array_map( 'array_flip', array_values( $possible_settings ) )
-			)
-		);
-
+		$flipped_arrays = array_map( 'array_flip', array_values( $possible_settings ) );
+		if ( count( $flipped_arrays ) < 2 ) {
+			// Handle the case when there is less than two arrays.
+			$interface_settings = $flipped_arrays[0] ?? [];
+		} else {
+				// Get the intersection of the arrays.
+				$interface_settings = array_keys( call_user_func_array( 'array_intersect_key', $flipped_arrays ) );
+		}
 		$interface_settings = array_merge( $settings, $interface_settings );
 
 		// Register the interface.

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -1,9 +1,9 @@
 <?php return array(
     'root' => array(
         'name' => 'harness-software/wp-graphql-gravity-forms',
-        'pretty_version' => 'dev-main',
-        'version' => 'dev-main',
-        'reference' => 'c49e1494144c984f54141da45471330d6ad1e637',
+        'pretty_version' => 'dev-develop',
+        'version' => 'dev-develop',
+        'reference' => '47727557e678b957bbaa36cea53ec5580cb1dc6b',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -11,9 +11,9 @@
     ),
     'versions' => array(
         'harness-software/wp-graphql-gravity-forms' => array(
-            'pretty_version' => 'dev-main',
-            'version' => 'dev-main',
-            'reference' => 'c49e1494144c984f54141da45471330d6ad1e637',
+            'pretty_version' => 'dev-develop',
+            'version' => 'dev-develop',
+            'reference' => '47727557e678b957bbaa36cea53ec5580cb1dc6b',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),

--- a/wp-graphql-gravity-forms.php
+++ b/wp-graphql-gravity-forms.php
@@ -13,6 +13,7 @@
  * Requires at least: 5.4.1
  * Tested up to: 6.5
  * Requires PHP: 7.4
+ * Requires Plugins: wp-graphql
  * WPGraphQL requires at least: 1.9.0
  * GravityForms requires at least: 2.5.0
  * License: GPL-3


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

Fixes `PHPCompatibility` dependency to use `dev-develop` instead of `dev-master`.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

The v10.0 branch is `develop` not master.

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
