### PR TITLE
chore: add traversable type hints (first pass)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - chore: Update Composer deps and lint.
 - chore: Lock WPBrowser to <3.5.0 to prevent conflicts with Codeception.
 - chore: Implement strict PHPStan rules and fix resulting issues.
+- chore: Add traversable type hints throughout the codebase.
 - ci: Update GitHub Actions to latest versions.
 - ci: Test plugin compatibility with WordPress 6.5.0.
 - ci: Test plugin compatibility with PHP 8.2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - chore: Lock WPBrowser to <3.5.0 to prevent conflicts with Codeception.
 - chore: Implement strict PHPStan rules and fix resulting issues.
 - chore: Add traversable type hints throughout the codebase.
+- tests: Lint tests.
 - ci: Update GitHub Actions to latest versions.
 - ci: Test plugin compatibility with WordPress 6.5.0.
 - ci: Test plugin compatibility with PHP 8.2.

--- a/src/CoreSchemaFilters.php
+++ b/src/CoreSchemaFilters.php
@@ -35,8 +35,10 @@ class CoreSchemaFilters implements Hookable {
 	/**
 	 * Strip `Connection` interface from form fields.
 	 *
-	 * @param array $interfaces Array of interfaces.
-	 * @param array $config  The type config.
+	 * @param string[]            $interfaces Array of interfaces.
+	 * @param array<string,mixed> $config     The type config.
+	 *
+	 * @return string[]
 	 */
 	public static function strip_connection_interface_from_gf_fields( array $interfaces, array $config ): array {
 		// Bail early if Connection, 'Edge, or 'OneToOneConnection' arent in the interfaces.

--- a/src/Data/Connection/EntriesConnectionResolver.php
+++ b/src/Data/Connection/EntriesConnectionResolver.php
@@ -53,7 +53,7 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Return the name of the loader to be used with the connection resolver
+	 * {@inheritDoc}
 	 */
 	public function get_loader_name(): string {
 		return EntriesLoader::$name;
@@ -220,6 +220,8 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 	 * Gets index (array offset) and offset (entry id) from decoded cursor.
 	 *
 	 * @param string $cursor .
+	 *
+	 * @return array{index:int,offset:int}
 	 */
 	protected function parse_cursor( string $cursor ): array {
 		$decoded     = base64_decode( $cursor );
@@ -234,7 +236,7 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * Returns form ids.
 	 *
-	 * @return array|int
+	 * @return int[]|int
 	 */
 	private function get_form_ids() {
 		if ( empty( $this->args['where']['formIds'] ) ) {
@@ -250,6 +252,8 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 
 	/**
 	 * Gets search criteria for entry Ids.
+	 *
+	 * @return array<string,mixed>
 	 */
 	private function get_search_criteria(): array {
 		$search_criteria = $this->apply_status_to_search_criteria( [] );
@@ -275,7 +279,9 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * Adds 'status' value to search criteria.
 	 *
-	 * @param array $search_criteria The search criteria for the entry Ids.
+	 * @param array<string,mixed> $search_criteria The search criteria for the entry Ids.
+	 *
+	 * @return array<string,mixed>
 	 */
 	private function apply_status_to_search_criteria( array $search_criteria ): array {
 		$status = $this->args['where']['status'] ?? EntryStatusEnum::ACTIVE; // Default to active entries.
@@ -372,6 +378,8 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 
 	/**
 	 * Get sort argument for entry ID query.
+	 *
+	 * @return array<string,mixed>
 	 */
 	private function get_sort(): array {
 		// Set default sort direction.
@@ -397,6 +405,8 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 
 	/**
 	 * Get paging arguments for entry ID query.
+	 *
+	 * @return array{offset:int,page_size:int}
 	 *
 	 * @throws \GraphQL\Error\UserError When using unsupported pagination.
 	 */

--- a/src/Data/Connection/FormFieldsConnectionResolver.php
+++ b/src/Data/Connection/FormFieldsConnectionResolver.php
@@ -33,7 +33,9 @@ class FormFieldsConnectionResolver {
 	 *
 	 * Instead of a Model.
 	 *
-	 * @param array $data array of form fields.
+	 * @param \GF_Field[] $data array of form fields.
+	 *
+	 * @return \GF_Field[]
 	 */
 	public static function prepare_data( array $data ): array {
 		foreach ( $data as &$field ) {
@@ -73,11 +75,11 @@ class FormFieldsConnectionResolver {
 	 * The connection resolve method.
 	 *
 	 * @param mixed                                $source  The object the connection is coming from.
-	 * @param array                                $args    Array of args to be passed down to the resolve method.
+	 * @param array<string,mixed>                  $args    Array of args to be passed down to the resolve method.
 	 * @param \WPGraphQL\AppContext                $context The AppContext object to be passed down.
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object.
 	 *
-	 * @return mixed|array|\WPGraphQL\GF\Data\Connection\Deferred
+	 * @return ?array<string,mixed>
 	 */
 	public static function resolve( $source, array $args, AppContext $context, ResolveInfo $info ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		if ( ! is_array( $source ) || empty( $source ) ) {
@@ -104,6 +106,8 @@ class FormFieldsConnectionResolver {
 
 	/**
 	 * Returns input keys for Address field.
+	 *
+	 * @return string[]
 	 */
 	private static function get_address_input_keys(): array {
 		return [
@@ -118,6 +122,8 @@ class FormFieldsConnectionResolver {
 
 	/**
 	 * Returns input keys for Name field.
+	 *
+	 * @return string[]
 	 */
 	private static function get_name_input_keys(): array {
 		return [
@@ -132,8 +138,10 @@ class FormFieldsConnectionResolver {
 		/**
 		 * Filters the form fields by the connection's where args.
 		 *
-		 * @param array $fields .
-		 * @param array $args .
+		 * @param \GF_Field[]         $fields .
+		 * @param array<string,mixed> $args .
+		 *
+		 * @return \GF_Field[]
 		 */
 	private static function filter_form_fields_by_connection_args( $fields, $args ): array {
 		if ( isset( $args['where']['ids'] ) ) {

--- a/src/Data/Connection/FormsConnectionResolver.php
+++ b/src/Data/Connection/FormsConnectionResolver.php
@@ -118,7 +118,7 @@ class FormsConnectionResolver extends AbstractConnectionResolver {
 			 * client. This hook is somewhat similar to Gravity Forms' gform_pre_render hook
 			 * and can be used for dynamic field input population, among other things.
 			 *
-			 * @param array $form Form meta array.
+			 * @param array<string,mixed> $form Form meta array.
 			 */
 			$modified_form = apply_filters( 'graphql_gf_form_object', $form );
 

--- a/src/Data/Connection/FormsConnectionResolver.php
+++ b/src/Data/Connection/FormsConnectionResolver.php
@@ -93,7 +93,7 @@ class FormsConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @return array
+	 * @return array<int|string,array<string,mixed>>
 	 */
 	public function get_query(): array {
 		$form_ids    = $this->query_args['form_ids'];
@@ -147,6 +147,8 @@ class FormsConnectionResolver extends AbstractConnectionResolver {
 
 	/**
 	 * Returns form ids.
+	 *
+	 * @return int[]
 	 */
 	private function get_form_ids(): array {
 		if ( empty( $this->args['where']['formIds'] ) ) {
@@ -162,6 +164,8 @@ class FormsConnectionResolver extends AbstractConnectionResolver {
 
 	/**
 	 * Gets form status from query.
+	 *
+	 * @return array{active:bool,trash:bool}
 	 */
 	private function get_form_status(): array {
 		$status = $this->args['where']['status'] ?? FormStatusEnum::ACTIVE;
@@ -195,6 +199,8 @@ class FormsConnectionResolver extends AbstractConnectionResolver {
 
 	/**
 	 * Get sort argument for forms ID query.
+	 *
+	 * @return array{key:string,direction:string}
 	 *
 	 * @throws \GraphQL\Error\UserError .
 	 */

--- a/src/Data/EntryObjectMutation.php
+++ b/src/Data/EntryObjectMutation.php
@@ -21,10 +21,10 @@ class EntryObjectMutation {
 	/**
 	 * Returns the FieldValueInput object relative to the field type.
 	 *
-	 * @param array $args The GraphQL mutation input args for the field.
-	 * @param array $form The GF form object.
-	 * @param bool  $is_draft If the mutation is for a draft entry.
-	 * @param array $entry The GF entry object. Used when updating.
+	 * @param array<string,mixed>     $args     The GraphQL mutation input args for the field.
+	 * @param array<string,mixed>     $form     The GF form object.
+	 * @param bool                    $is_draft If the mutation is for a draft entry.
+	 * @param array<int|string,mixed> $entry    The GF entry object. Used when updating.
 	 *
 	 * @throws \Exception .
 	 */
@@ -92,12 +92,12 @@ class EntryObjectMutation {
 		 *
 		 * Useful for adding mutation support for custom fields.
 		 *
-		 * @param string $field_value_input_class  The FieldValueInput class to use. The referenced class must extend AbstractFieldValueInput.
-		 * @param array    $args The GraphQL input args for the form field.
-		 * @param \GF_Field $field The current Gravity Forms field object.
-		 * @param array $form The current Gravity Forms form object.
-		 * @param array|null $entry The current Gravity Forms entry object. Only available when using update (`gfUpdateEntry`, `gfUpdateDraftEntry`) mutations.
-		 * @param bool $is_draft_mutation Whether the mutation is handling a Draft Entry (`gfUpdateDraftEntry`, or `gfSubmitForm` when `saveAsDraft` is `true`).
+		 * @param string              $field_value_input_class  The FieldValueInput class to use. The referenced class must extend AbstractFieldValueInput.
+		 * @param array               $args The GraphQL input args for the form field.
+		 * @param \GF_Field           $field The current Gravity Forms field object.
+		 * @param array<string,mixed> $form The current Gravity Forms form object.
+		 * @param array|null          $entry The current Gravity Forms entry object. Only available when using update (`gfUpdateEntry`, `gfUpdateDraftEntry`) mutations.
+		 * @param bool                $is_draft_mutation Whether the mutation is handling a Draft Entry (`gfUpdateDraftEntry`, or `gfSubmitForm` when `saveAsDraft` is `true`).
 		 */
 		$field_value_input = apply_filters( 'graphql_gf_field_value_input_class', $field_value_input, $args, $field, $form, $entry, $is_draft );
 
@@ -129,7 +129,9 @@ class EntryObjectMutation {
 	/**
 	 * Gets the submission confirmation information in an array formated for WPGraphQL.
 	 *
-	 * @param array $payload the submission response.
+	 * @param array<string,mixed> $payload the submission response.
+	 *
+	 * @return ?array{type:string,message:?string,url:?string}
 	 */
 	public static function get_submission_confirmation( array $payload ): ?array {
 		if ( empty( $payload['confirmation_type'] ) ) {
@@ -147,6 +149,8 @@ class EntryObjectMutation {
 	 * Renames $field_value keys to input_{id}_{sub_id}, so Gravity Forms can read them.
 	 *
 	 * @param array $field_values .
+	 *
+	 * @return array<string,mixed> $formatted .
 	 * */
 	public static function rename_field_names_for_submission( array $field_values ): array {
 		$formatted = [];
@@ -162,9 +166,9 @@ class EntryObjectMutation {
 	 * Initializes the globals needed for file uploads to work.
 	 * This prevents any notices about missing array keys.
 	 *
-	 * @param \GF_Field[] $form_fields .
-	 * @param array       $input_field_values .
-	 * @param bool        $save_as_draft .
+	 * @param \GF_Field[]           $form_fields .
+	 * @param array<string,mixed>[] $input_field_values .
+	 * @param bool                  $save_as_draft .
 	 *
 	 * @throws \GraphQL\Error\UserError .
 	 */

--- a/src/Data/EntryObjectMutation.php
+++ b/src/Data/EntryObjectMutation.php
@@ -111,7 +111,9 @@ class EntryObjectMutation {
 	/**
 	 * Generates array of field errors from the submission.
 	 *
-	 * @param array $messages The Gravity Forms submission validation messages.
+	 * @param array<int|string,string> $messages The Gravity Forms submission validation messages.
+	 *
+	 * @return array{message:string,id:int|string}[]
 	 */
 	public static function get_submission_errors( array $messages ): array {
 		return array_map(
@@ -148,7 +150,7 @@ class EntryObjectMutation {
 	/**
 	 * Renames $field_value keys to input_{id}_{sub_id}, so Gravity Forms can read them.
 	 *
-	 * @param array $field_values .
+	 * @param array<int|string,mixed> $field_values .
 	 *
 	 * @return array<string,mixed> $formatted .
 	 * */
@@ -156,7 +158,7 @@ class EntryObjectMutation {
 		$formatted = [];
 
 		foreach ( $field_values as $key => $value ) {
-			$formatted[ 'input_' . str_replace( '.', '_', $key ) ] = $value;
+			$formatted[ 'input_' . str_replace( '.', '_', (string) $key ) ] = $value;
 		}
 
 		return $formatted;
@@ -169,6 +171,8 @@ class EntryObjectMutation {
 	 * @param \GF_Field[]           $form_fields .
 	 * @param array<string,mixed>[] $input_field_values .
 	 * @param bool                  $save_as_draft .
+	 *
+	 * @return array<string,array<string,mixed>[]>
 	 *
 	 * @throws \GraphQL\Error\UserError .
 	 */

--- a/src/Data/Factory.php
+++ b/src/Data/Factory.php
@@ -27,10 +27,10 @@ class Factory {
 	/**
 	 * Registers loaders to AppContext.
 	 *
-	 * @param array                 $loaders Data loaders.
-	 * @param \WPGraphQL\AppContext $context App context.
+	 * @param array<string,\WPGraphQL\Data\Loader\AbstractDataLoader> $loaders Data loaders.
+	 * @param \WPGraphQL\AppContext                                   $context App context.
 	 *
-	 * @return array Data loaders, with new ones added.
+	 * @return array<string,\WPGraphQL\Data\Loader\AbstractDataLoader> Data loaders.
 	 */
 	public static function register_loaders( array $loaders, AppContext $context ): array {
 		$loaders[ DraftEntriesLoader::$name ] = new DraftEntriesLoader( $context );
@@ -69,7 +69,7 @@ class Factory {
 	 *
 	 * @param int                                  $max_query_amount Max query amount.
 	 * @param mixed                                $source     source passed down from the resolve tree.
-	 * @param array                                $args       array of arguments input in the field as part of the GraphQL query.
+	 * @param array<string,mixed>                  $args       array of arguments input in the field as part of the GraphQL query.
 	 * @param \WPGraphQL\AppContext                $context Object containing app context that gets passed down the resolve tree.
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info Info about fields passed down the resolve tree.
 	 *
@@ -97,11 +97,11 @@ class Factory {
 	 * Wrapper for the FormsConnectionResolver::resolve method.
 	 *
 	 * @param mixed                                $source  The object the connection is coming from.
-	 * @param array                                $args    Array of args to be passed down to the resolve method.
+	 * @param array<string,mixed>                  $args    Array of args to be passed down to the resolve method.
 	 * @param \WPGraphQL\AppContext                $context The AppContext object to be passed down.
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object.
 	 *
-	 * @return mixed|array|\GraphQL\Deferred
+	 * @return \GraphQL\Deferred
 	 */
 	public static function resolve_forms_connection( $source, array $args, AppContext $context, ResolveInfo $info ) {
 		$resolver = new FormsConnectionResolver( $source, $args, $context, $info );
@@ -133,11 +133,11 @@ class Factory {
 	 * Wrapper for the EntriesConnectionResolver::resolve method.
 	 *
 	 * @param mixed                                $source  The object the connection is coming from.
-	 * @param array                                $args    Array of args to be passed down to the resolve method.
+	 * @param array<string,mixed>                  $args    Array of args to be passed down to the resolve method.
 	 * @param \WPGraphQL\AppContext                $context The AppContext object to be passed down.
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object.
 	 *
-	 * @return mixed|array|\GraphQL\Deferred
+	 * @return \GraphQL\Deferred
 	 */
 	public static function resolve_entries_connection( $source, array $args, AppContext $context, ResolveInfo $info ) {
 		$resolver = new EntriesConnectionResolver( $source, $args, $context, $info );

--- a/src/Data/FieldValueInput/AbstractFieldValueInput.php
+++ b/src/Data/FieldValueInput/AbstractFieldValueInput.php
@@ -54,7 +54,7 @@ abstract class AbstractFieldValueInput {
 	/**
 	 * The GraphQL input args passed to `fieldValues`.
 	 *
-	 * @var array
+	 * @var array<string,mixed>
 	 */
 	protected array $input_args;
 
@@ -75,11 +75,11 @@ abstract class AbstractFieldValueInput {
 	/**
 	 * The class constructor.
 	 *
-	 * @param array                        $input_args The GraphQL input args for the form field.
-	 * @param array<string,mixed>          $form The current Gravity Forms form object.
-	 * @param bool                         $is_draft Whether the mutation is handling a Draft Entry.
-	 * @param \GF_Field                    $field The current Gravity Forms field object.
-	 * @param array<int|string,mixed>|null $entry The current Gravity Forms entry object.
+	 * @param array<string,mixed>          $input_args The GraphQL input args for the form field.
+	 * @param array<string,mixed>          $form       The current Gravity Forms form object.
+	 * @param bool                         $is_draft   Whether the mutation is handling a Draft Entry.
+	 * @param \GF_Field                    $field      The current Gravity Forms field object.
+	 * @param array<int|string,mixed>|null $entry      The current Gravity Forms entry object.
 	 *
 	 * @throws \GraphQL\Error\UserError .
 	 */
@@ -122,12 +122,12 @@ abstract class AbstractFieldValueInput {
 		/**
 		 * Filters the GraphQL input args for the field value input.
 		 *
-		 * @param array|string $args field value input args.
-		 * @param \GF_Field $field The current Gravity Forms field object.
-		 * @param array $form The current Gravity Forms form object.
-		 * @param array|null $entry The current Gravity Forms entry object. Only available when using update (`gfUpdateEntry`, `gfUpdateDraftEntry`) mutations.
-		 * @param bool $is_draft_mutation Whether the mutation is handling a Draft Entry (`gfUpdateDraftEntry`, or `gfSubmitForm` when `saveAsDraft` is `true`).
-		 * @param string $field_name The GraphQL input field name. E.g. `nameValues`.
+		 * @param array|string        $args              Field value input args.
+		 * @param \GF_Field           $field The current Gravity Forms field object.
+		 * @param array<string,mixed> $form The current  Gravity Forms form object.
+		 * @param array|null          $entry The current Gravity Forms entry object. Only available when using update (`gfUpdateEntry`, `gfUpdateDraftEntry`) mutations.
+		 * @param bool                $is_draft_mutation Whether the mutation is handling a Draft Entry (`gfUpdateDraftEntry`, or `gfSubmitForm` when `saveAsDraft` is `true`).
+		 * @param string              $field_name        The GraphQL input field name. E.g. `nameValues`.
 		 */
 		$this->args = apply_filters(
 			'graphql_gf_field_value_input_args',
@@ -142,13 +142,13 @@ abstract class AbstractFieldValueInput {
 		/**
 		 * Filters the prepared field value to be submitted to Gravity Forms.
 		 *
-		 * @param array|string $prepared_field_value The field value formatted in a way Gravity Forms can understand.
-		 * @param array|string $args field value input args.
-		 * @param \GF_Field $field The current Gravity Forms field object.
-		 * @param array $form The current Gravity Forms form object.
-		 * @param array|null $entry The current Gravity Forms entry object. Only available when using update (`gfUpdateEntry`, `gfUpdateDraftEntry`) mutations.
-		 * @param bool $is_draft_mutation Whether the mutation is handling a Draft Entry (`gfUpdateDraftEntry`, or `gfSubmitForm` when `saveAsDraft` is `true`).
-		 * @param string $field_name The GraphQL input field name. E.g. `nameValues`.
+		 * @param array|string        $prepared_field_value The field value formatted in a way Gravity Forms can understand.
+		 * @param array|string        $args                 Field value input args.
+		 * @param \GF_Field           $field                The current Gravity Forms field object.
+		 * @param array<string,mixed> $form                 The current Gravity Forms form object.
+		 * @param array|null          $entry                The current Gravity Forms entry object. Only available when using update (`gfUpdateEntry`, `gfUpdateDraftEntry`) mutations.
+		 * @param bool                $is_draft_mutation    Whether the mutation is handling a Draft Entry (`gfUpdateDraftEntry`, or `gfSubmitForm` when `saveAsDraft` is `true`).
+		 * @param string              $field_name           The GraphQL input field name. E.g. `nameValues`.
 		 */
 		$this->value = apply_filters(
 			'graphql_gf_field_value_input_prepared_value',

--- a/src/Extensions/GFChainedSelects/GFChainedSelects.php
+++ b/src/Extensions/GFChainedSelects/GFChainedSelects.php
@@ -125,9 +125,9 @@ class GFChainedSelects implements Hookable {
 	/**
 	 * Registers the SignatureValuesInput class.
 	 *
-	 * @param string    $input_class .
-	 * @param array     $args .
-	 * @param \GF_Field $field .
+	 * @param class-string        $input_class .
+	 * @param array<string,mixed> $args .
+	 * @param \GF_Field           $field .
 	 */
 	public static function field_value_input( string $input_class, array $args, GF_Field $field ): string {
 		if ( 'chainedselect' === $field->get_input_type() ) {

--- a/src/Extensions/GFChainedSelects/GFChainedSelects.php
+++ b/src/Extensions/GFChainedSelects/GFChainedSelects.php
@@ -62,7 +62,9 @@ class GFChainedSelects implements Hookable {
 	/**
 	 * Register enum classes.
 	 *
-	 * @param array $registered_classes .
+	 * @param class-string[] $registered_classes .
+	 *
+	 * @return class-string[]
 	 */
 	public static function enums( array $registered_classes ): array {
 		$registered_classes[] = Enum\ChainedSelectFieldAlignmentEnum::class;
@@ -72,7 +74,9 @@ class GFChainedSelects implements Hookable {
 	/**
 	 * Register input classes.
 	 *
-	 * @param array $registered_classes .
+	 * @param class-string[] $registered_classes .
+	 *
+	 * @return class-string[]
 	 */
 	public static function inputs( array $registered_classes ): array {
 		$registered_classes[] = Input\ChainedSelectFieldInput::class;
@@ -82,7 +86,9 @@ class GFChainedSelects implements Hookable {
 	/**
 	 * Registers the mapped list of GF form field settings to their interface classes.
 	 *
-	 * @param array $classes .
+	 * @param array<string,class-string> $classes .
+	 *
+	 * @return array<string,class-string>
 	 */
 	public static function form_field_settings( array $classes ): array {
 		$classes['chained_choices_setting']               = WPInterface\FieldSetting\FieldWithChainedChoices::class;
@@ -95,7 +101,8 @@ class GFChainedSelects implements Hookable {
 	/**
 	 * Registers the mapped list of GF form field settings to their choice interface classes.
 	 *
-	 * @param array $classes .
+	 * @param array<string,class-string> $classes .
+	 * @return array<string,class-string>
 	 */
 	public static function form_field_setting_choices( array $classes ): array {
 		$classes['chained_choices_setting'] = WPInterface\FieldChoiceSetting\ChoiceWithChainedChoices::class;
@@ -106,7 +113,8 @@ class GFChainedSelects implements Hookable {
 	/**
 	 * Registers the mapped list of GF form field settings to their choice interface classes.
 	 *
-	 * @param array $classes .
+	 * @param array<string,class-string> $classes .
+	 * @return array<string,class-string>
 	 */
 	public static function form_field_setting_inputs( array $classes ): array {
 		$classes['chained_choices_setting'] = WPInterface\FieldInputSetting\InputWithChainedChoices::class;
@@ -132,8 +140,10 @@ class GFChainedSelects implements Hookable {
 	/**
 	 * Registers ChainedSelect field value.
 	 *
-	 * @param array     $fields .
-	 * @param \GF_Field $field .
+	 * @param array<string,array<string,mixed>> $fields .
+	 * @param \GF_Field                         $field .
+	 *
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function field_value_fields( array $fields, GF_Field $field ): array {
 		if ( 'chainedselect' === $field->get_input_type() ) {
@@ -146,7 +156,9 @@ class GFChainedSelects implements Hookable {
 	/**
 	 * Registers `fieldValues` input fields.
 	 *
-	 * @param array $fields .
+	 * @param array<string,array<string,mixed>> $fields .
+	 *
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function field_values_input_fields( array $fields ): array {
 		if ( ! isset( $fields['chainedSelectValues'] ) ) {
@@ -162,7 +174,9 @@ class GFChainedSelects implements Hookable {
 	/**
 	 * Maps the Gravity Forms Field type to a safe GraphQL type (in PascalCase ).
 	 *
-	 * @param array $fields_to_map .
+	 * @param array<string,string> $fields_to_map .
+	 *
+	 * @return array<string,string>
 	 */
 	public static function form_field_name( array $fields_to_map ): array {
 		$fields_to_map['chainedselect'] = 'ChainedSelect';

--- a/src/Extensions/GFChainedSelects/Type/WPInterface/FieldChoiceSetting/ChoiceWithChainedChoices.php
+++ b/src/Extensions/GFChainedSelects/Type/WPInterface/FieldChoiceSetting/ChoiceWithChainedChoices.php
@@ -53,10 +53,12 @@ class ChoiceWithChainedChoices extends AbstractFieldChoiceSetting {
 	/**
 	 * Registers a GraphQL field to the GraphQL type that implements this interface.
 	 *
-	 * @param array     $fields An array of GraphQL field configs.
-	 * @param string    $choice_name The name of the choice type.
-	 * @param \GF_Field $field The Gravity Forms Field object.
-	 * @param array     $settings The `form_editor_field_settings()` key.
+	 * @param array<string,array<string,mixed>> $fields An array of GraphQL field configs.
+	 * @param string                            $choice_name The name of the choice type.
+	 * @param \GF_Field                         $field The Gravity Forms Field object.
+	 * @param string[]                          $settings The `form_editor_field_settings()` keys.
+	 *
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function add_fields_to_child_type( array $fields, string $choice_name, GF_Field $field, array $settings ): array {
 		if (

--- a/src/Extensions/GFChainedSelects/Type/WPInterface/FieldSetting/FieldWithChainedChoices.php
+++ b/src/Extensions/GFChainedSelects/Type/WPInterface/FieldSetting/FieldWithChainedChoices.php
@@ -75,7 +75,9 @@ class FieldWithChainedChoices extends AbstractFieldSetting implements TypeWithIn
 	/**
 	 * Adds the `chained_choices_setting` setting to the list of settings that have the GraphQL choices field.
 	 *
-	 * @param array $settings the GF Field settings.
+	 * @param string[] $settings the GF Field settings.
+	 *
+	 * @return string[]
 	 */
 	public static function add_setting( array $settings ): array {
 		if ( ! in_array( self::$field_setting, $settings, true ) ) {

--- a/src/Extensions/GFChainedSelects/Type/WPObject/FormField/FieldValue/ValueProperty.php
+++ b/src/Extensions/GFChainedSelects/Type/WPObject/FormField/FieldValue/ValueProperty.php
@@ -17,6 +17,8 @@ use WPGraphQL\GF\Type\WPObject\FormField\FieldValue\FieldValues;
 class ValueProperty extends FieldValues {
 	/**
 	 * Get `values` property for Chained Select field.
+	 *
+	 * @return array{values:array<string,mixed>}
 	 */
 	public static function chained_select_values(): array {
 		return [

--- a/src/Extensions/GFQuiz/GFQuiz.php
+++ b/src/Extensions/GFQuiz/GFQuiz.php
@@ -53,7 +53,9 @@ class GFQuiz implements Hookable {
 	/**
 	 * Register enum classes.
 	 *
-	 * @param array $classes .
+	 * @param class-string[] $classes .
+	 *
+	 * @return class-string[]
 	 */
 	public static function enums( array $classes ): array {
 		$classes[] = Enum\QuizFieldGradingTypeEnum::class;
@@ -65,7 +67,9 @@ class GFQuiz implements Hookable {
 	/**
 	 * Registers the mapped list of GF form field settings to their interface classes.
 	 *
-	 * @param array $classes .
+	 * @param array<string,class-string> $classes .
+	 *
+	 * @return array<string,class-string>
 	 */
 	public static function form_field_settings( array $classes ): array {
 		$classes['gquiz-setting-choices']                 = WPInterface\FieldSetting\FieldWithQuizChoices::class;
@@ -79,7 +83,9 @@ class GFQuiz implements Hookable {
 	/**
 	 * Registers the mapped list of GF form field settings to their choice interface classes.
 	 *
-	 * @param array $classes .
+	 * @param array<string,class-string> $classes .
+	 *
+	 * @return array<string,class-string>
 	 */
 	public static function form_field_setting_choices( array $classes ): array {
 		$classes['gquiz-setting-choices'] = WPInterface\FieldChoiceSetting\ChoiceWithQuizChoices::class;
@@ -90,7 +96,9 @@ class GFQuiz implements Hookable {
 	/**
 	 * Register object classes.
 	 *
-	 * @param array $classes .
+	 * @param class-string[] $classes .
+	 *
+	 * @return class-string[]
 	 */
 	public static function objects( array $classes ): array {
 		$classes[] = WPObject\Entry\EntryQuizResults::class;
@@ -109,8 +117,10 @@ class GFQuiz implements Hookable {
 	/**
 	 * Sets the Form Field child types.
 	 *
-	 * @param array  $child_types An array of GF_Field::$type => GraphQL type names.
-	 * @param string $field_type The 'parent' GF_Field type.
+	 * @param array<string,string> $child_types An array of GF_Field::$type => GraphQL type names.
+	 * @param string               $field_type  The 'parent' GF_Field type.
+	 *
+	 * @return array<string,string>
 	 */
 	public static function field_child_types( array $child_types, string $field_type ): array {
 		if ( 'quiz' === $field_type ) {
@@ -129,9 +139,11 @@ class GFQuiz implements Hookable {
 	/**
 	 * Adds quiz to model
 	 *
-	 * @param array  $fields .
-	 * @param string $model_name .
-	 * @param array  $data .
+	 * @param array<string,mixed> $fields .
+	 * @param string              $model_name .
+	 * @param array<string,mixed> $data .
+	 *
+	 * @return array<string,mixed>
 	 */
 	public static function form_model( $fields, string $model_name, $data ): array {
 		if ( 'FormObject' === $model_name ) {

--- a/src/Extensions/GFQuiz/Type/WPInterface/FieldSetting/FieldWithQuizChoices.php
+++ b/src/Extensions/GFQuiz/Type/WPInterface/FieldSetting/FieldWithQuizChoices.php
@@ -53,7 +53,9 @@ class FieldWithQuizChoices extends AbstractFieldSetting {
 	/**
 	 * Adds the `chained_choices_setting` setting to the list of settings that have the GraphQL choices field.
 	 *
-	 * @param array $settings the GF Field settings.
+	 * @param string[] $settings the GF Field settings.
+	 *
+	 * @return string[]
 	 */
 	public static function add_setting( array $settings ): array {
 		if ( ! in_array( self::$field_setting, $settings, true ) ) {

--- a/src/Extensions/GFQuiz/Type/WPObject/QuizResults/QuizResults.php
+++ b/src/Extensions/GFQuiz/Type/WPObject/QuizResults/QuizResults.php
@@ -128,6 +128,8 @@ class QuizResults extends AbstractObject implements Field {
 	 *
 	 * @param array<string,mixed> $form           The form array.
 	 * @param array<string,mixed> $results_config The GFQuiz config array.
+	 *
+	 * @return array<string,mixed>
 	 */
 	protected static function get_quiz_results_data( array $form, array $results_config ): array {
 		if ( ! class_exists( 'GFResults' ) ) {
@@ -150,6 +152,8 @@ class QuizResults extends AbstractObject implements Field {
 	 *
 	 * @param array<string,mixed> $data The Quiz Results data.
 	 * @param array<string,mixed> $form The form array.
+	 *
+	 * @return array<string,mixed>
 	 */
 	protected static function prepare_results_data( array $data, array $form ): array {
 		if ( empty( $data['entry_count'] ) ) {
@@ -186,7 +190,9 @@ class QuizResults extends AbstractObject implements Field {
 	/**
 	 * Maps the score frequencies array into a format WPGraphQL can understand.
 	 *
-	 * @param array $score_frequencies the score frequences array. E.g. `[ $score => $count ]`.
+	 * @param array<mixed,mixed> $score_frequencies the score frequences array. E.g. `[ $score => $count ]`.
+	 *
+	 * @return array{score:mixed,count:mixed}[]
 	 */
 	private static function map_score_frequencies( array $score_frequencies ): array {
 		return array_map(
@@ -202,7 +208,8 @@ class QuizResults extends AbstractObject implements Field {
 	/**
 	 * Maps the grade frequencies array into a format WPGraphQL can understand.
 	 *
-	 * @param array $grade_frequencies the score frequences array. E.g. `[ $grade => $count ]`.
+	 * @param array<mixed,mixed> $grade_frequencies the score frequences array. E.g. `[ $grade => $count ]`.
+	 * @return array{grade:mixed,count:mixed}[]
 	 */
 	private static function map_grade_frequencies( array $grade_frequencies ): array {
 		return array_map(

--- a/src/Extensions/GFQuiz/Type/WPObject/QuizResults/QuizResults.php
+++ b/src/Extensions/GFQuiz/Type/WPObject/QuizResults/QuizResults.php
@@ -126,8 +126,8 @@ class QuizResults extends AbstractObject implements Field {
 	/**
 	 * Gets the Quiz Results data.
 	 *
-	 * @param array $form .
-	 * @param array $results_config the GFQuiz config array.
+	 * @param array<string,mixed> $form           The form array.
+	 * @param array<string,mixed> $results_config The GFQuiz config array.
 	 */
 	protected static function get_quiz_results_data( array $form, array $results_config ): array {
 		if ( ! class_exists( 'GFResults' ) ) {
@@ -148,8 +148,8 @@ class QuizResults extends AbstractObject implements Field {
 	/**
 	 * Transforms the results data for the GraphQL response.
 	 *
-	 * @param array $data The Quiz Results data.
-	 * @param array $form .
+	 * @param array<string,mixed> $data The Quiz Results data.
+	 * @param array<string,mixed> $form The form array.
 	 */
 	protected static function prepare_results_data( array $data, array $form ): array {
 		if ( empty( $data['entry_count'] ) ) {
@@ -218,9 +218,11 @@ class QuizResults extends AbstractObject implements Field {
 	/**
 	 * Maps the field data array to a format WPGraphQL can understand.
 	 *
-	 * @param array $field_data . The field data array.
-	 * @param array $form .
-	 * @param int   $entry_count . The number of submitted entries.
+	 * @param array<string,mixed> $field_data  The field data array.
+	 * @param array<string,mixed> $form        The form array.
+	 * @param int                 $entry_count The number of submitted entries.
+	 *
+	 * @return array<int,array<string,mixed>>
 	 */
 	private static function map_field_data( array $field_data, array $form, int $entry_count ): array {
 		return array_map(

--- a/src/Extensions/GFSignature/GFSignature.php
+++ b/src/Extensions/GFSignature/GFSignature.php
@@ -45,18 +45,23 @@ class GFSignature implements Hookable {
 	/**
 	 * Register enum classes.
 	 *
-	 * @param array $registered_classes .
+	 * @param class-string[] $registered_classes The registered classes.
+	 *
+	 * @return class-string[]
 	 */
 	public static function enums( array $registered_classes ): array {
 		$registered_classes[] = Enum\SignatureFieldBorderStyleEnum::class;
 		$registered_classes[] = Enum\SignatureFieldBorderWidthEnum::class;
+
 		return $registered_classes;
 	}
 
 	/**
 	 * Registers the mapped list of GF form field settings to their interface classes.
 	 *
-	 * @param array $classes .
+	 * @param array<string,class-string> $classes The registered classes.
+	 *
+	 * @return array<string,class-string>
 	 */
 	public static function form_field_settings( array $classes ): array {
 		$classes['background_color_setting'] = WPInterface\FieldSetting\FieldWithBackgroundColor::class;

--- a/src/Extensions/GFSignature/GFSignature.php
+++ b/src/Extensions/GFSignature/GFSignature.php
@@ -78,9 +78,9 @@ class GFSignature implements Hookable {
 	/**
 	 * Registers the SignatureValuesInput class.
 	 *
-	 * @param string    $input_class .
-	 * @param array     $args .
-	 * @param \GF_Field $field .
+	 * @param class-string        $input_class .
+	 * @param array<string,mixed> $args .
+	 * @param \GF_Field           $field .
 	 */
 	public static function field_value_input( string $input_class, array $args, GF_Field $field ): string {
 		if ( 'signature' === $field->get_input_type() ) {

--- a/src/Extensions/WPGatsby/GravityFormsMonitor.php
+++ b/src/Extensions/WPGatsby/GravityFormsMonitor.php
@@ -24,7 +24,7 @@ class GravityFormsMonitor extends \WPGatsby\ActionMonitor\Monitors\Monitor {
 	/**
 	 * An array of enabled actions to monitor.
 	 *
-	 * @var array
+	 * @var string[]
 	 */
 	public static array $enabled_actions;
 
@@ -69,8 +69,8 @@ class GravityFormsMonitor extends \WPGatsby\ActionMonitor\Monitors\Monitor {
 	/**
 	 * Logs a Gatsby action.
 	 *
-	 * @param string $action_name the name of the action defined in the settings.
-	 * @param array  $args the action config.
+	 * @param string              $action_name the name of the action defined in the settings.
+	 * @param array<string,mixed> $args the action config.
 	 */
 	public function log( string $action_name, array $args ): void {
 		if ( ! in_array( $action_name, self::$enabled_actions, true ) ) {
@@ -141,8 +141,8 @@ class GravityFormsMonitor extends \WPGatsby\ActionMonitor\Monitors\Monitor {
 	/**
 	 * Triggers either `after_create_form()` or `after_update_form()`
 	 *
-	 * @param array $form .
-	 * @param bool  $is_new whether the form was created or updated.
+	 * @param array<string,mixed> $form   The form array.
+	 * @param bool                $is_new Whether the form was created or updated.
 	 */
 	public function after_save_form( array $form, bool $is_new ): void {
 		if ( $is_new ) {
@@ -174,7 +174,7 @@ class GravityFormsMonitor extends \WPGatsby\ActionMonitor\Monitors\Monitor {
 	/**
 	 * Triggers a Gatsby `log_action()` after an entry is created.
 	 *
-	 * @param array $entry .
+	 * @param array<int|string,mixed> $entry The entry array.
 	 */
 	public function after_create_entry( array $entry ): void {
 		$args = [
@@ -193,8 +193,8 @@ class GravityFormsMonitor extends \WPGatsby\ActionMonitor\Monitors\Monitor {
 	/**
 	 * Triggers a Gatsby `log_action()` after an entry is updated.
 	 *
-	 * @param array $form .
-	 * @param int   $entry_id .
+	 * @param array<string,mixed> $form The form array.
+	 * @param int                 $entry_id The entry ID.
 	 */
 	public function after_update_entry( array $form, int $entry_id ): void {
 		$args = [
@@ -213,7 +213,7 @@ class GravityFormsMonitor extends \WPGatsby\ActionMonitor\Monitors\Monitor {
 	/**
 	 * Wraps `after_update_entry()` for specific gf actions.
 	 *
-	 * @param array $entry .
+	 * @param array<int|string,mixed> $entry The entry array.
 	 */
 	public function post_update_entry( array $entry ): void {
 		$this->after_update_entry( [], $entry['id'] );
@@ -224,8 +224,8 @@ class GravityFormsMonitor extends \WPGatsby\ActionMonitor\Monitors\Monitor {
 	 *
 	 * Currently unused, as Draft Entries arent yet part of the schema.
 	 *
-	 * @param array  $submission .
-	 * @param string $resume_token .
+	 * @param array<int|string,mixed> $submission .
+	 * @param string                  $resume_token .
 	 */
 	public function after_save_draft_entry( array $submission, string $resume_token ): void {
 		$args = [

--- a/src/Extensions/WPGatsby/Settings.php
+++ b/src/Extensions/WPGatsby/Settings.php
@@ -89,9 +89,11 @@ class Settings {
 
 	/**
 	 * Gets an array of Gravity Forms actions that should be monitored.
+	 *
+	 * @return string[] An array of enabled actions.
 	 */
 	public static function get_enabled_actions(): array {
-		/** @var array $options */
+		/** @var array<string,mixed> $options */
 		$options = get_option( self::$section_name, [] );
 
 		// By default monitor everything.
@@ -107,7 +109,7 @@ class Settings {
 		 * Filter for overriding the list of enabled actions.
 		 * Possible array values: `create_form`, `update_form`, `delete_form`, `create_entry`, `update_entry`.
 		 *
-		 * @param array $enabled_actions. An array of enabled actions.
+		 * @param string[] $enabled_actions. An array of enabled actions.
 		 */
 		return apply_filters( 'graphql_gf_gatsby_enabled_actions', array_values( $enabled_actions ) ?: [] );
 	}

--- a/src/Extensions/WPGatsby/WPGatsby.php
+++ b/src/Extensions/WPGatsby/WPGatsby.php
@@ -37,8 +37,10 @@ class WPGatsby implements Hookable {
 	/**
 	 * Registers the custom Action Monitor.
 	 *
-	 * @param array                                 $monitors .
-	 * @param \WPGatsby\ActionMonitor\ActionMonitor $action_monitor .
+	 * @param array<string,\WPGatsby\ActionMonitor\Monitors\Monitor> $monitors .
+	 * @param \WPGatsby\ActionMonitor\ActionMonitor                  $action_monitor .
+	 *
+	 * @return array<string,\WPGatsby\ActionMonitor\Monitors\Monitor>
 	 */
 	public static function register_monitors( array $monitors, \WPGatsby\ActionMonitor\ActionMonitor $action_monitor ): array {
 		$monitors['GravityFormsMonitor'] = new GravityFormsMonitor( $action_monitor );

--- a/src/Extensions/WPJamstackDeployments/WPJamstackDeployments.php
+++ b/src/Extensions/WPJamstackDeployments/WPJamstackDeployments.php
@@ -24,7 +24,7 @@ class WPJamstackDeployments implements Hookable {
 	/**
 	 * The options array.
 	 *
-	 * @var array
+	 * @var array<string,mixed>
 	 */
 	public static array $options;
 
@@ -61,6 +61,8 @@ class WPJamstackDeployments implements Hookable {
 
 	/**
 	 * Returns the array of options.
+	 *
+	 * @return array<string,mixed>
 	 */
 	public static function get_options(): array {
 		if ( empty( self::$options ) ) {
@@ -106,7 +108,9 @@ class WPJamstackDeployments implements Hookable {
 	/**
 	 * Sanitize user input.
 	 *
-	 * @param array $input .
+	 * @param array<string,mixed> $input .
+	 *
+	 * @return array<string,mixed>
 	 */
 	public static function sanitize( array $input ): array {
 		if ( ! isset( $input[ self::$option_name ] ) || ! is_array( $input[ self::$option_name ] ) ) {
@@ -162,8 +166,8 @@ class WPJamstackDeployments implements Hookable {
 	/**
 	 * Triggers the correct deployment when a form is saved.
 	 *
-	 * @param array $form .
-	 * @param bool  $is_new .
+	 * @param array<string,mixed> $form The form array.
+	 * @param bool                $is_new .
 	 */
 	public static function after_save_form( array $form, bool $is_new ): void {
 		$options = self::get_options();

--- a/src/Model/DraftEntry.php
+++ b/src/Model/DraftEntry.php
@@ -20,14 +20,14 @@ class DraftEntry extends Model {
 	/**
 	 * Stores the incoming DraftEntry to be modeled.
 	 *
-	 * @var array $data
+	 * @var array<int|string,mixed> $data
 	 */
 	protected $data;
 
 	/**
 	 * Stores the decoded draft entry Submission.
 	 *
-	 * @var array $submission
+	 * @var array<int|string,mixed> $submission
 	 */
 	protected $submission;
 
@@ -41,8 +41,8 @@ class DraftEntry extends Model {
 	/**
 	 * DraftEntry constructor.
 	 *
-	 * @param array  $entry The incoming DraftEntry to be modeled.
-	 * @param string $resume_token the resume token to use.
+	 * @param array<int|string,mixed> $entry The incoming DraftEntry to be modeled.
+	 * @param string                  $resume_token the resume token to use.
 	 *
 	 * @throws \Exception .
 	 */

--- a/src/Model/Form.php
+++ b/src/Model/Form.php
@@ -19,14 +19,14 @@ class Form extends Model {
 	/**
 	 * Stores the incoming form to be modeled.
 	 *
-	 * @var array $data;
+	 * @var array<string,mixed> $data;
 	 */
 	protected $data;
 
 	/**
 	 * Form constructor.
 	 *
-	 * @param array $form The incoming form to be modeled.
+	 * @param array<string,mixed> $form The incoming form to be modeled.
 	 *
 	 * @throws \Exception .
 	 */

--- a/src/Model/SubmittedEntry.php
+++ b/src/Model/SubmittedEntry.php
@@ -20,14 +20,14 @@ class SubmittedEntry extends Model {
 	/**
 	 * Stores the incoming Gravity Forms entry to be modeled.
 	 *
-	 * @var array $data;
+	 * @var array<int|string,mixed> $data;
 	 */
 	protected $data;
 
 	/**
 	 * Entry constructor.
 	 *
-	 * @param array $entry The incoming entry to be modeled.
+	 * @param array<int|string,mixed> $entry The incoming entry to be modeled.
 	 *
 	 * @throws \Exception .
 	 */
@@ -55,10 +55,10 @@ class SubmittedEntry extends Model {
 		 *
 		 * @since 0.10.0
 		 *
-		 * @param bool      $can_view_entries Whether the current user should be allowed to view form entries.
-		 * @param int       $form_id The specific form ID being queried.
-		 * @param int       $entry_id The specific entry ID being queried.
-		 * @param array     $entry the current entry.
+		 * @param bool                    $can_view_entries Whether the current user should be allowed to view form entries.
+		 * @param int                     $form_id          The specific form ID being queried.
+		 * @param int                     $entry_id         The specific entry ID being queried.
+		 * @param array<int|string,mixed> $entry            The entry array.
 		 */
 		$can_view = apply_filters( 'graphql_gf_can_view_entries', $can_view, $this->data['form_id'], (int) $this->data['id'], $this->data );
 

--- a/src/Mutation/AbstractMutation.php
+++ b/src/Mutation/AbstractMutation.php
@@ -47,7 +47,8 @@ abstract class AbstractMutation extends AbstractType implements Mutation {
 	/**
 	 * Checks that necessary WPGraphQL are set.
 	 *
-	 * @param array $input .
+	 * @param ?array<string,mixed> $input .
+	 *
 	 * @throws \GraphQL\Error\UserError .
 	 */
 	protected static function check_required_inputs( ?array $input ): void {

--- a/src/Mutation/SubmitForm.php
+++ b/src/Mutation/SubmitForm.php
@@ -174,7 +174,9 @@ class SubmitForm extends AbstractMutation {
 	/**
 	 * Prepares draft entry object for update.
 	 *
-	 * @param array $input .
+	 * @param array<string|int,mixed> $input The input values.
+	 *
+	 * @return array{created_by?:int,date_created?:string,ip?:string,source_url?:string,user_agent?:string}
 	 */
 	private static function prepare_entry_data( array $input ): array {
 		$data = [];
@@ -207,7 +209,13 @@ class SubmitForm extends AbstractMutation {
 	}
 
 	/**
-	 * {@inheritDoc}
+	 * Converts the provided field values into a format that Gravity Forms can understand.
+	 *
+	 * @param array<string,mixed>[] $field_values The field values.
+	 * @param array<string,mixed>   $form The form object.
+	 * @param bool                  $save_as_draft Whether to save the submission as a draft.
+	 *
+	 * @return array<string,mixed>
 	 */
 	private static function prepare_field_values( array $field_values, array $form, bool $save_as_draft ): array {
 		$formatted_values = [];
@@ -225,9 +233,9 @@ class SubmitForm extends AbstractMutation {
 	/**
 	 * Updates entry properties that cannot be set with GFAPI::submit_form().
 	 *
-	 * @param array $form .
-	 * @param array $submission The Gravity Forms submission result array.
-	 * @param array $entry_meta .
+	 * @param array<string,mixed>     $form The Gravity Forms form array.
+	 * @param array<int|string,mixed> $submission The Gravity Forms submission result array.
+	 * @param array<string,mixed>     $entry_meta The entry meta data.
 	 * @throws \GraphQL\Error\UserError .
 	 */
 	private static function update_entry_properties( array $form, array $submission, array $entry_meta ): void {
@@ -273,9 +281,9 @@ class SubmitForm extends AbstractMutation {
 	/**
 	 * Creates the $input_values array required by GFAPI::submit_form().
 	 *
-	 * @param bool  $is_draft .
-	 * @param array $field_values . Required so submit_form() can generate the $_POST object.
-	 * @param array $file_upload_values .
+	 * @param bool                $is_draft .
+	 * @param array<string,mixed> $field_values Required so submit_form() can generate the $_POST object.
+	 * @param array               $file_upload_values .
 	 */
 	private static function get_input_values( bool $is_draft, array $field_values, array $file_upload_values ): array {
 		$input_values = [

--- a/src/Mutation/SubmitForm.php
+++ b/src/Mutation/SubmitForm.php
@@ -283,7 +283,9 @@ class SubmitForm extends AbstractMutation {
 	 *
 	 * @param bool                $is_draft .
 	 * @param array<string,mixed> $field_values Required so submit_form() can generate the $_POST object.
-	 * @param array               $file_upload_values .
+	 * @param array<string,mixed> $file_upload_values .
+	 *
+	 * @return array<string,mixed>
 	 */
 	private static function get_input_values( bool $is_draft, array $field_values, array $file_upload_values ): array {
 		$input_values = [

--- a/src/Mutation/UpdateDraftEntry.php
+++ b/src/Mutation/UpdateDraftEntry.php
@@ -131,9 +131,11 @@ class UpdateDraftEntry extends AbstractMutation {
 	/**
 	 * Prepares draft entry object for update.
 	 *
-	 * @param array $input .
-	 * @param array $submission .
-	 * @param array $form .
+	 * @param array<string,mixed>     $input GraphQL mutation input.
+	 * @param array<int|string,mixed> $submission .
+	 * @param array<string,mixed>     $form The form object.
+	 *
+	 * @return array<string,mixed>
 	 */
 	private static function prepare_draft_entry_data( array $input, array $submission, array $form ): array {
 		$should_validate = isset( $input['shouldValidate'] ) ? (bool) $input['shouldValidate'] : true;
@@ -189,11 +191,13 @@ class UpdateDraftEntry extends AbstractMutation {
 	/**
 	 * Converts the provided field values into a format that Gravity Forms can understand.
 	 *
-	 * @param array $field_values .
-	 * @param array $form .
-	 * @param array $entry .
-	 * @param array $submission .
-	 * @param bool  $should_validate .
+	 * @param array<string,mixed>[]   $field_values .
+	 * @param array<string,mixed>     $form The form object.
+	 * @param array<int|string,mixed> $entry The entry object.
+	 * @param array<int|string,mixed> $submission .
+	 * @param bool                    $should_validate .
+	 *
+	 * @return array<int|string,mixed>
 	 */
 	private static function prepare_field_values( array $field_values, array $form, array $entry, array &$submission, bool $should_validate ): array {
 		$formatted_values = [];

--- a/src/Mutation/UpdateEntry.php
+++ b/src/Mutation/UpdateEntry.php
@@ -143,9 +143,11 @@ class UpdateEntry extends AbstractMutation {
 	/**
 	 * Prepares entry object for update.
 	 *
-	 * @param array $input .
-	 * @param array $entry .
-	 * @param array $form .
+	 * @param array<string,mixed>     $input The GraphQL input.
+	 * @param array<int|string,mixed> $entry The entry array.
+	 * @param array<string,mixed>     $form The form array.
+	 *
+	 * @return array<int|string,mixed> The prepared entry data.
 	 * @throws \GraphQL\Error\UserError .
 	 */
 	private static function prepare_entry_data( array $input, array $entry, array $form ): array {
@@ -245,10 +247,10 @@ class UpdateEntry extends AbstractMutation {
 	/**
 	 * Converts the provided field values into a format that Gravity Forms can understand.
 	 *
-	 * @param array $field_values .
-	 * @param array $entry .
-	 * @param array $form .
-	 * @param bool  $should_validate .
+	 * @param array<string,mixed>[]   $field_values .
+	 * @param array<int|string,mixed> $entry The entry array.
+	 * @param array<string,mixed>     $form The form array.
+	 * @param bool                    $should_validate .
 	 */
 	private static function prepare_field_values( array $field_values, array $entry, array $form, bool $should_validate ): array {
 		$formatted_values = [];
@@ -269,9 +271,9 @@ class UpdateEntry extends AbstractMutation {
 	/**
 	 * Prepares field values before saving it to the entry.
 	 *
-	 * @param array $values the entry values.
-	 * @param array $entry the existing entry.
-	 * @param array $form the existing form.
+	 * @param array                   $values the entry values.
+	 * @param array<int|string,mixed> $entry the existing entry.
+	 * @param array<string,mixed>     $form The form array.
 	 */
 	public static function prepare_field_values_for_save( array $values, array $entry, array $form ): array {
 		// We need the entry fresh to prepare the values.
@@ -294,8 +296,8 @@ class UpdateEntry extends AbstractMutation {
 	/**
 	 * Grabs the updated entry, and then updates the post.
 	 *
-	 * @param int   $entry_id .
-	 * @param array $form .
+	 * @param int                 $entry_id .
+	 * @param array<string,mixed> $form The form array.
 	 */
 	public static function update_post( int $entry_id, array $form ): void {
 		$entry = GFUtils::get_entry( $entry_id );
@@ -308,9 +310,9 @@ class UpdateEntry extends AbstractMutation {
 	/**
 	 * Sets the post id so GFFormsModel::create_post updates the post instead of creating a new one.
 	 *
-	 * @param array $post_data .
-	 * @param array $form .
-	 * @param array $entry .
+	 * @param array<string,mixed>     $post_data .
+	 * @param array<string,mixed>     $form The form array.
+	 * @param array<int|string,mixed> $entry .
 	 */
 	public static function set_post_id_for_update( array $post_data, array $form, array $entry ): array {
 		$post_data['ID'] = $entry['post_id'];

--- a/src/Registry/FieldChoiceRegistry.php
+++ b/src/Registry/FieldChoiceRegistry.php
@@ -28,7 +28,7 @@ class FieldChoiceRegistry {
 	 *
 	 * @since 0.12.2
 	 *
-	 * @var array
+	 * @var string[]
 	 */
 	public static $registered_types = [];
 
@@ -52,7 +52,7 @@ class FieldChoiceRegistry {
 	 * Registers the Choice property for the GF Form Field as a GraphQL object.
 	 *
 	 * @param \GF_Field $field The Gravity Forms field object.
-	 * @param array     $settings The Gravity Forms field settings used to define the GraphQL object.
+	 * @param string[]  $settings The Gravity Forms field settings used to define the GraphQL object.
 	 * @param bool      $as_interface Whether to register the choice as an interface. Default false.
 	 */
 	public static function register( GF_Field $field, array $settings, bool $as_interface = false ): void {
@@ -98,7 +98,9 @@ class FieldChoiceRegistry {
 	 *
 	 * @param string    $choice_name The name of the choice.
 	 * @param \GF_Field $field The Gravity Forms field object.
-	 * @param array     $settings The Gravity Forms field settings.
+	 * @param string[]  $settings The Gravity Forms field settings.
+	 *
+	 * @return array<string,mixed>
 	 */
 	public static function get_config_from_settings( string $choice_name, GF_Field $field, array $settings ): array {
 		$interfaces = self::get_interfaces( $settings );
@@ -120,7 +122,9 @@ class FieldChoiceRegistry {
 	/**
 	 * Returns the config array used to register the form field choice.
 	 *
-	 * @param array $settings .
+	 * @param string[] $settings .
+	 *
+	 * @return string[]
 	 */
 	public static function get_interfaces( array $settings ): array {
 		// Every Choice is a FieldChoice.
@@ -155,8 +159,10 @@ class FieldChoiceRegistry {
 	 *
 	 * @param string    $choice_name .
 	 * @param \GF_Field $field The Gravity Forms field object.
-	 * @param array     $settings The Gravity Forms field settings.
-	 * @param array     $interfaces The list of interfaces to add to the field.
+	 * @param string[]  $settings The Gravity Forms field settings.
+	 * @param string[]  $interfaces The list of interfaces to add to the field.
+	 *
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_fields( string $choice_name, GF_Field $field, array $settings, array $interfaces ): array {
 		$fields = FieldChoice::get_fields();
@@ -164,11 +170,11 @@ class FieldChoiceRegistry {
 		/**
 		 * Filter to modify the Form Field Choice GraphQL fields.
 		 *
-		 * @param array    $fields An array of GraphQL field configs. See https://www.wpgraphql.com/functions/register_graphql_fields/
-		 * @param string   $choice_name The name of the choice type.
-		 * @param \GF_Field $field The Gravity Forms Field object.
-		 * @param array    $settings The `form_editor_field_settings()` keys.
-		 * @param array    $interfaces The list of interfaces for the GraphQL type.
+		 * @param array<string,array<string,mixed>> $fields An array of GraphQL field configs. See https://www.wpgraphql.com/functions/register_graphql_fields/
+		 * @param string                            $choice_name The name of the choice type.
+		 * @param \GF_Field                         $field The Gravity Forms Field object.
+		 * @param string[]                          $settings The `form_editor_field_settings()` keys.
+		 * @param string[]                          $interfaces The list of interfaces for the GraphQL type.
 		 */
 		$fields = apply_filters( 'graphql_gf_form_field_setting_choice_fields', $fields, $choice_name, $field, $settings, $interfaces );
 

--- a/src/Registry/FieldInputRegistry.php
+++ b/src/Registry/FieldInputRegistry.php
@@ -28,7 +28,7 @@ class FieldInputRegistry {
 	 *
 	 * @since 0.12.2
 	 *
-	 * @var array
+	 * @var string[]
 	 */
 	public static $registered_types = [];
 
@@ -55,7 +55,7 @@ class FieldInputRegistry {
 	 * Registers the Input property for the GF Form Field as a GraphQL object.
 	 *
 	 * @param \GF_Field $field The Gravity Forms field object.
-	 * @param array     $settings The Gravity Forms field settings used to define the GraphQL object.
+	 * @param string[]  $settings The Gravity Forms field settings used to define the GraphQL object.
 	 * @param bool      $as_interface Whether to register the choice as an interface. Default false.
 	 */
 	public static function register( GF_Field $field, array $settings, bool $as_interface = false ): void {
@@ -100,7 +100,9 @@ class FieldInputRegistry {
 	 *
 	 * @param string    $input_name The name of the input.
 	 * @param \GF_Field $field The Gravity Forms field object.
-	 * @param array     $settings The Gravity Forms field settings.
+	 * @param string[]  $settings The Gravity Forms field settings.
+	 *
+	 * @return array<string,mixed>
 	 */
 	public static function get_config_from_settings( string $input_name, GF_Field $field, array $settings ): array {
 		$interfaces = self::get_interfaces( $settings );
@@ -122,7 +124,9 @@ class FieldInputRegistry {
 	/**
 	 * Returns the config array used to register the form field input.
 	 *
-	 * @param array $settings .
+	 * @param string[] $settings .
+	 *
+	 * @return string[]
 	 */
 	public static function get_interfaces( array $settings ): array {
 		// Every Input is a FieldInput.
@@ -157,8 +161,10 @@ class FieldInputRegistry {
 	 *
 	 * @param string    $input_name .
 	 * @param \GF_Field $field The Gravity Forms field object.
-	 * @param array     $settings The Gravity Forms field settings.
-	 * @param array     $interfaces The list of interfaces to add to the field.
+	 * @param string[]  $settings The Gravity Forms field settings.
+	 * @param string[]  $interfaces The list of interfaces to add to the field.
+	 *
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_fields( string $input_name, GF_Field $field, array $settings, array $interfaces ): array {
 		$fields = FieldInput::get_fields();
@@ -166,11 +172,11 @@ class FieldInputRegistry {
 		/**
 		 * Filter to modify the Form Field Input GraphQL fields.
 		 *
-		 * @param array    $fields An array of GraphQL field configs. See https://www.wpgraphql.com/functions/register_graphql_fields/
-		 * @param string   $input_name The name of the input type.
-		 * @param \GF_Field $field The Gravity Forms Field object.
-		 * @param array    $settings The `form_editor_field_settings()` key.
-		 * @param array    $interfaces The list of interfaces for the GraphQL type.
+		 * @param array<string,array<string,mixed>> $fields An array of GraphQL field configs. See https://www.wpgraphql.com/functions/register_graphql_fields/
+		 * @param string                            $input_name The name of the input type.
+		 * @param \GF_Field                         $field The Gravity Forms Field object.
+		 * @param string[]                          $settings The `form_editor_field_settings()` keys.
+		 * @param string[]                          $interfaces The list of interfaces for the GraphQL type.
 		 */
 		$fields = apply_filters( 'graphql_gf_form_field_setting_input_fields', $fields, $input_name, $field, $settings, $interfaces );
 

--- a/src/Registry/FormFieldRegistry.php
+++ b/src/Registry/FormFieldRegistry.php
@@ -71,7 +71,7 @@ class FormFieldRegistry {
 		 * The fields themselves will only be registered on the next get_graphql_register_action() call.
 		 *
 		 * @param \GF_Field $field The Gravity Forms field object.
-		 * @param array    $field_settings The field settings.
+		 * @param string[]  $field_settings The field settings.
 		 */
 		do_action( 'graphql_gf_after_register_form_field', $field, $field_settings );
 		do_action( 'graphql_gf_after_register_form_field_' . $field->graphql_single_name, $field, $field_settings );
@@ -80,9 +80,9 @@ class FormFieldRegistry {
 	/**
 	 * Registers the GF Form Field as a GraphQL object, wrapped in actions to keep things DRY.
 	 *
-	 * @param \GF_Field $field The Gravity Forms field object.
-	 * @param array     $field_settings The Gravity Forms field settings.
-	 * @param array     $config The config array as expected by WPGraphQL.
+	 * @param \GF_Field           $field The Gravity Forms field object.
+	 * @param string[]            $field_settings The Gravity Forms field settings.
+	 * @param array<string,mixed> $config The config array as expected by WPGraphQL.
 	 */
 	protected static function register_object_type( GF_Field $field, array $field_settings, array $config ): void {
 		add_action(
@@ -99,8 +99,8 @@ class FormFieldRegistry {
 				 * Fires after the Gravity Forms field object has been registered to WPGraphQL schema.
 				 *
 				 * @param \GF_Field $field The Gravity Forms field object.
-				 * @param array    $field_settings The field settings.
-				 * @param array    $config The config array as expected by WPGraphQL.
+				 * @param string[]  $field_settings The field settings.
+				 * @param array<string,mixed> $config The config array as expected by WPGraphQL.
 				 */
 				do_action( 'graphql_gf_after_register_form_field_object', $field, $field_settings, $config );
 				do_action( 'graphql_gf_after_register_form_field_object_' . $field->graphql_single_name, $field, $field_settings, $config );
@@ -113,9 +113,9 @@ class FormFieldRegistry {
 	 *
 	 * @uses FormFields::register_gf_field_object() to register the child types.
 	 *
-	 * @param \GF_Field $field The Gravity Forms field object.
-	 * @param array     $settings       The field settings.
-	 * @param array     $possible_types The possible child types of the field. Null if no child types.
+	 * @param \GF_Field            $field          The Gravity Forms field object.
+	 * @param string[]             $settings       The field settings.
+	 * @param array<string,string> $possible_types The possible child types of the field. Null if no child types.
 	 */
 	protected static function register_interface_and_types( GF_Field $field, array $settings, array $possible_types ): void {
 		// Store these for later use.
@@ -242,10 +242,10 @@ class FormFieldRegistry {
 	/**
 	 * Returns the config array used to register the form field.
 	 *
-	 * @param \GF_Field $field .
-	 * @param array     $settings .
+	 * @param \GF_Field $field The Gravity Forms field object.
+	 * @param string[]  $settings The Gravity Forms field setting keys.
 	 *
-	 * @return array{interfaces:string[],fields:array}
+	 * @return array{interfaces:string[],fields:array<string,array<string,mixed>>}
 	 */
 	public static function get_config_from_settings( GF_Field $field, array $settings ): array {
 		// Every GF_field is a FormField.
@@ -341,8 +341,8 @@ class FormFieldRegistry {
 	 * Gets the GraphQL fields config for the form field.
 	 *
 	 * @param \GF_Field $field The Gravity Forms field object.
-	 * @param array     $settings The Gravity Forms field settings.
-	 * @param array     $interfaces The list of interfaces to add to the field.
+	 * @param string[]  $settings The Gravity Forms field settings.
+	 * @param string[]  $interfaces The list of interfaces to add to the field.
 	 *
 	 * @return array<string,array<string,mixed>> The GraphQL fields config.
 	 */
@@ -356,10 +356,10 @@ class FormFieldRegistry {
 				 *
 				 * @deprecated 0.12.0 Use `graphql_gf_form_field_setting_fields` instead.
 				 *
-				 * @param array    $fields An array of GraphQL field configs. See https://www.wpgraphql.com/functions/register_graphql_fields/
-				 * @param string    $setting_key   The `form_editor_field_settings()` key.
-				 * @param \GF_Field $field The Gravity Forms Field object.
-				 * @param array    $interfaces The list of interfaces for the GraphQL type.
+				 * @param array<string,array<string,mixed>> $fields      An array of GraphQL field configs. See https://www.wpgraphql.com/functions/register_graphql_fields/
+				 * @param string                            $setting_key The `form_editor_field_settings()` key.
+				 * @param \GF_Field                         $field       The Gravity Forms Field object.
+				 * @param string[]                          $interfaces  The list of interfaces for the GraphQL type.
 				 */
 				$fields = apply_filters_deprecated( 'graphql_gf_form_field_setting_properties', [ $fields, $setting_key, $field ], '0.12.0', 'graphql_gf_form_field_setting_fields' );
 			}
@@ -370,8 +370,8 @@ class FormFieldRegistry {
 		 *
 		 * @param array<string,array<string,mixed>> $fields An array of GraphQL field configs. See https://www.wpgraphql.com/functions/register_graphql_fields/
 		 * @param \GF_Field                         $field The Gravity Forms Field object.
-		 * @param array                             $settings The `form_editor_field_settings()` key.
-		 * @param array                             $interfaces The list of interfaces for the GraphQL type.
+		 * @param string[]                          $settings The `form_editor_field_settings()` keys.
+		 * @param string[]                          $interfaces The list of interfaces for the GraphQL type.
 		 */
 		$fields = apply_filters( 'graphql_gf_form_field_setting_fields', $fields, $field, $settings, $interfaces );
 
@@ -382,6 +382,8 @@ class FormFieldRegistry {
 	 * Gets the Field Value field config.
 	 *
 	 * @param \GF_Field $field The Gravity Forms field object.
+	 *
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_field_value_fields( GF_Field $field ): array {
 		$fields = [];
@@ -442,16 +444,16 @@ class FormFieldRegistry {
 		 *
 		 * @deprecated 0.12.0 Use `graphql_gf_form_field_value_fields` instead.
 		 *
-		 * @param array $fields An array of GraphQL field configs. See https://www.wpgraphql.com/functions/register_graphql_fields/
-		 * @param \GF_Field $field The Gravity Forms Field object.
+		 * @param array<string,array<string,mixed>> $fields An array of GraphQL field configs. See https://www.wpgraphql.com/functions/register_graphql_fields/
+		 * @param \GF_Field                         $field The Gravity Forms Field object.
 		 */
 		$fields = apply_filters_deprecated( 'graphql_gf_form_field_value_properties', [ $fields, $field ], '0.12.0', 'graphql_gf_form_field_value_fields' );
 
 		/**
 		 * Filter to modify the Form Field Value GraphQL fields.
 		 *
-		 * @param array    $fields An array of GraphQL field configs. See https://www.wpgraphql.com/functions/register_graphql_fields/
-		 * @param \GF_Field $field The Gravity Forms Field object.
+		 * @param array<string,array<string,mixed>> $fields An array of GraphQL field configs. See https://www.wpgraphql.com/functions/register_graphql_fields/
+		 * @param \GF_Field                         $field The Gravity Forms Field object.
 		 */
 		$fields = apply_filters( 'graphql_gf_form_field_value_fields', $fields, $field );
 
@@ -462,17 +464,17 @@ class FormFieldRegistry {
 	 * Calls the actions to register the choices and inputs to the type.
 	 *
 	 * @param \GF_Field $field The Gravity Forms field object.
-	 * @param array     $field_settings The Gravity Forms field settings.
+	 * @param string[]  $field_settings The Gravity Forms field settings.
 	 * @param bool      $as_interface   Whether to register the choices and inputs as an interface.
 	 */
 	protected static function maybe_register_choices_and_inputs( GF_Field $field, array $field_settings, bool $as_interface = false ): void {
 		/**
 		 * Filters the Gravity Forms field settings that should have a `choices` GraphQL Field.
 		 *
-		 * @param array    $settings_with_choices The field settings that should have a `choices` GraphQL Field.
-		 * @param array    $field_settings The Gravity Forms field settings.
-		 * @param \GF_Field $field The Gravity Forms field object.
-		 * @param bool     $as_interface Whether to register the choice as an interface.
+		 * @param string[]    $settings_with_choices The field settings that should have a `choices` GraphQL Field.
+		 * @param string[]    $field_settings The Gravity Forms field settings.
+		 * @param \GF_Field   $field The Gravity Forms field object.
+		 * @param bool        $as_interface Whether to register the choice as an interface.
 		 */
 		$settings_with_choices = apply_filters(
 			'graphql_gf_form_field_settings_with_choices',
@@ -497,8 +499,8 @@ class FormFieldRegistry {
 		/**
 		 * Filters the Gravity Forms field settings that should have an `inputs` GraphQL Field.
 		 *
-		 * @param array    $settings_with_inputs The field settings that should have an `inputs` GraphQL Field.
-		 * @param array    $field_settings The Gravity Forms field settings.
+		 * @param string[]    $settings_with_inputs The field settings that should have an `inputs` GraphQL Field.
+		 * @param string[]    $field_settings The Gravity Forms field settings.
 		 * @param \GF_Field $field The Gravity Forms field object.
 		 * @param bool     $as_interface Whether to register the inputs as an interface.
 		 */

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -25,7 +25,7 @@ class TypeRegistry {
 	/**
 	 * The local registry of registered types.
 	 *
-	 * @var array
+	 * @var array<string,class-string<\WPGraphQL\GF\Interfaces\Hookable>>
 	 */
 	public static array $registry = [];
 
@@ -38,6 +38,8 @@ class TypeRegistry {
 
 	/**
 	 * Gets an array of all the registered GraphQL types along with their class name.
+	 *
+	 * @return array<string,class-string<\WPGraphQL\GF\Interfaces\Hookable>>
 	 */
 	public static function get_registered_types(): array {
 		if ( empty( self::$registry ) ) {
@@ -49,6 +51,8 @@ class TypeRegistry {
 
 	/**
 	 * Gets an array of all the registered GraphQL types along with their class name.
+	 *
+	 * @return class-string[]
 	 */
 	public static function get_registered_classes(): array {
 		if ( empty( self::$registered_classes ) ) {
@@ -387,7 +391,7 @@ class TypeRegistry {
 		/**
 		 * Filters the list of PHP classes that register GraphQL Interfaces based on a particular Gravity Forms field setting.
 		 *
-		 * @param array           $classes_to_register Array of classes to be registered to the schema.
+		 * @param array<string,class-string> $classes_to_register Array of classes to be registered to the schema.
 		 */
 		$classes_to_register = apply_filters( 'graphql_gf_registered_form_field_setting_classes', $classes_to_register );
 
@@ -415,7 +419,7 @@ class TypeRegistry {
 		/**
 		 * Filters the list of PHP classes that register GraphQL Interfaces for Form Field choices based on a particular Gravity Forms field setting.
 		 *
-		 * @param array           $classes_to_register Array of classes to be registered to the schema.
+		 * @param array<string,class-string> $classes_to_register Array of classes to be registered to the schema.
 		 */
 		$classes_to_register = apply_filters( 'graphql_gf_registered_form_field_setting_input_classes', $classes_to_register );
 
@@ -439,7 +443,7 @@ class TypeRegistry {
 		/**
 		 * Filters the list of PHP classes that register GraphQL Interfaces for Form Field choices based on a particular Gravity Forms field setting.
 		 *
-		 * @param array           $classes_to_register Array of classes to be registered to the schema.
+		 * @param array<string,class-string> $classes_to_register Array of classes to be registered to the schema.
 		 */
 		$classes_to_register = apply_filters( 'graphql_gf_registered_form_field_setting_choice_classes', $classes_to_register );
 
@@ -448,6 +452,8 @@ class TypeRegistry {
 
 	/**
 	 * List of Field classes to register.
+	 *
+	 * @return class-string[]
 	 */
 	public static function fields(): array {
 		$classes_to_register = [];
@@ -457,13 +463,15 @@ class TypeRegistry {
 		 *
 		 * Useful for adding/removing GF specific fields to the schema.
 		 *
-		 * @param array           $classes_to_register Array of classes to be registered to the schema.
+		 * @param class-string[] $classes_to_register Array of classes to be registered to the schema.
 		 */
 		return apply_filters( 'graphql_gf_registered_field_classes', $classes_to_register );
 	}
 
 	/**
 	 * List of Connection classes to register.
+	 *
+	 * @return class-string[]
 	 */
 	public static function connections(): array {
 		$classes_to_register = [
@@ -477,13 +485,15 @@ class TypeRegistry {
 		 *
 		 * Useful for adding/removing GF specific connections to the schema.
 		 *
-		 * @param array           $classes_to_register Array of classes to be registered to the schema.
+		 * @param class-string[] $classes_to_register Array of classes to be registered to the schema.
 		 */
 		return apply_filters( 'graphql_gf_registered_connection_classes', $classes_to_register );
 	}
 
 	/**
 	 * Registers mutation.
+	 *
+	 * @return class-string[]
 	 */
 	public static function mutations(): array {
 		$classes_to_register = [
@@ -500,7 +510,7 @@ class TypeRegistry {
 		 *
 		 * Useful for adding/removing GF specific connections to the schema.
 		 *
-		 * @param array           $classes_to_register Array of classes to be registered to the schema.
+		 * @param class-string[] $classes_to_register Array of classes to be registered to the schema.
 		 */
 		$classes_to_register = apply_filters( 'graphql_gf_registered_mutation_classes', $classes_to_register );
 
@@ -512,7 +522,7 @@ class TypeRegistry {
 	 *
 	 * Classes must extend WPGraphQL\Type\AbstractType.
 	 *
-	 * @param array $classes_to_register .
+	 * @param class-string[] $classes_to_register .
 	 *
 	 * @throws \Exception .
 	 */
@@ -532,7 +542,10 @@ class TypeRegistry {
 
 			// Saves the Type => ClassName to the local registry.
 			if ( isset( $class::$type ) ) {
-				self::$registry[ $class::$type ] = $class;
+				/** @var string $type */
+				$type = $class::$type;
+
+				self::$registry[ $type ] = $class;
 			}
 		}
 	}

--- a/src/Type/WPInterface/Entry.php
+++ b/src/Type/WPInterface/Entry.php
@@ -196,10 +196,14 @@ class Entry extends AbstractInterface implements TypeWithConnections, TypeWithIn
 
 					$order = \Gravity_Forms\Gravity_Forms\Orders\Factories\GF_Order_Factory::create_from_entry( $context->gfForm->form, $source->entry );
 
-					/** @var array $items */
+					/** @var \Gravity_Forms\Gravity_Forms\Orders\Items\GF_Order_Item[]|\Gravity_Forms\Gravity_Forms\Orders\Items\GF_Order_Item|null $items */
 					$items = $order->get_items();
 					if ( empty( $items ) ) {
 						return null;
+					}
+
+					if ( $items instanceof \Gravity_Forms\Gravity_Forms\Orders\Items\GF_Order_Item ) {
+						$items = [ $items ];
 					}
 
 					// Convert order items to array.

--- a/src/Type/WPInterface/FieldChoiceSetting/ChoiceWithChoices.php
+++ b/src/Type/WPInterface/FieldChoiceSetting/ChoiceWithChoices.php
@@ -53,11 +53,13 @@ class ChoiceWithChoices extends AbstractFieldChoiceSetting {
 	/**
 	 * Registers a GraphQL field to the GraphQL type that implements this interface.
 	 *
-	 * @param array     $fields An array of GraphQL field configs.
-	 * @param string    $choice_name The name of the choice type.
-	 * @param \GF_Field $field The Gravity Forms Field object.
-	 * @param array     $settings The `form_editor_field_settings()` key.
-	 * @param array     $interfaces The list of interfaces for the GraphQL type.
+	 * @param array<string,array<string,mixed>> $fields An array of GraphQL field configs.
+	 * @param string                            $choice_name The name of the choice type.
+	 * @param \GF_Field                         $field The Gravity Forms Field object.
+	 * @param string[]                          $settings The `form_editor_field_settings()` keys.
+	 * @param string[]                          $interfaces The list of interfaces for the GraphQL type.
+	 *
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function add_fields_to_child_type( array $fields, string $choice_name, GF_Field $field, array $settings, array $interfaces ): array {
 		if (

--- a/src/Type/WPInterface/FieldChoiceSetting/ChoiceWithName.php
+++ b/src/Type/WPInterface/FieldChoiceSetting/ChoiceWithName.php
@@ -55,8 +55,8 @@ class ChoiceWithName extends AbstractFieldChoiceSetting {
 	/**
 	 * Registers a GraphQL field to the GraphQL type that implements this interface.
 	 *
-	 * @param \GF_Field $field The Gravity Forms Field object.
-	 * @param array     $settings The `form_editor_field_settings()` key.
+	 * @param \GF_Field $field    The Gravity Forms Field object.
+	 * @param string[]  $settings The `form_editor_field_settings()` keys.
 	 */
 	public static function add_choice_to_inputs( GF_Field $field, array $settings ): void {
 		if (

--- a/src/Type/WPInterface/FieldChoiceSetting/ChoiceWithOtherChoice.php
+++ b/src/Type/WPInterface/FieldChoiceSetting/ChoiceWithOtherChoice.php
@@ -53,11 +53,13 @@ class ChoiceWithOtherChoice extends AbstractFieldChoiceSetting {
 	/**
 	 * Registers a GraphQL field to the GraphQL type that implements this interface.
 	 *
-	 * @param array     $fields An array of GraphQL field configs.
-	 * @param string    $choice_name The name of the choice type.
-	 * @param \GF_Field $field The Gravity Forms Field object.
-	 * @param array     $settings The `form_editor_field_settings()` key.
-	 * @param array     $interfaces The list of interfaces for the GraphQL type.
+	 * @param array<string,array<string,mixed>> $fields An array of GraphQL field configs.
+	 * @param string                            $choice_name The name of the choice type.
+	 * @param \GF_Field                         $field The Gravity Forms Field object.
+	 * @param string[]                          $settings The `form_editor_field_settings()` keys.
+	 * @param string[]                          $interfaces The list of interfaces for the GraphQL type.
+	 *
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function add_fields_to_child_type( array $fields, string $choice_name, GF_Field $field, array $settings, array $interfaces ): array {
 		if (

--- a/src/Type/WPInterface/FieldSetting/FieldWithAutocomplete.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithAutocomplete.php
@@ -53,10 +53,12 @@ class FieldWithAutocomplete extends AbstractFieldSetting {
 	/**
 	 * Registers a GraphQL field to the GraphQL type that implements this interface.
 	 *
-	 * @param array     $fields An array of GraphQL field configs.
-	 * @param \GF_Field $field The Gravity Forms Field object.
-	 * @param array     $settings The `form_editor_field_settings()` key.
-	 * @param array     $interfaces The list of interfaces for the GraphQL type.
+	 * @param array<string,array<string,mixed>> $fields An array of GraphQL field configs.
+	 * @param \GF_Field                         $field The Gravity Forms Field object.
+	 * @param string[]                          $settings The `form_editor_field_settings()` keys.
+	 * @param string[]                          $interfaces The list of interfaces for the GraphQL type.
+	 *
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function add_fields_to_child_type( array $fields, GF_Field $field, array $settings, array $interfaces ): array {
 		// Bail early.

--- a/src/Type/WPInterface/FieldSetting/FieldWithPrepopulateField.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithPrepopulateField.php
@@ -53,10 +53,12 @@ class FieldWithPrepopulateField extends AbstractFieldSetting {
 	/**
 	 * Registers a GraphQL field to the GraphQL type that implements this interface.
 	 *
-	 * @param array     $fields An array of GraphQL field configs.
-	 * @param \GF_Field $field The Gravity Forms Field object.
-	 * @param array     $settings The `form_editor_field_settings()` key.
-	 * @param array     $interfaces The list of interfaces for the GraphQL type.
+	 * @param array<string,array<string,mixed>> $fields An array of GraphQL field configs.
+	 * @param \GF_Field                         $field The Gravity Forms Field object.
+	 * @param string[]                          $settings The `form_editor_field_settings()` keys.
+	 * @param string[]                          $interfaces The list of interfaces for the GraphQL type.
+	 *
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function add_fields_to_child_type( array $fields, GF_Field $field, array $settings, array $interfaces ): array {
 		// Bail early.

--- a/src/Type/WPObject/FormField/FieldValue/FieldValues.php
+++ b/src/Type/WPObject/FormField/FieldValue/FieldValues.php
@@ -25,6 +25,8 @@ use WPGraphQL\GF\Utils\Utils;
 class FieldValues {
 	/**
 	 * Get `value` property.
+	 *
+	 * @return array{value:array<string,mixed>}
 	 */
 	public static function value(): array {
 		return [
@@ -44,6 +46,8 @@ class FieldValues {
 
 	/**
 	 * Get `addressValues` property.
+	 *
+	 * @return array{addressValues:array<string,mixed>}
 	 */
 	public static function address_values(): array {
 		return [
@@ -70,6 +74,8 @@ class FieldValues {
 
 	/**
 	 * Get `checkboxValues` property.
+	 *
+	 * @return array{checkboxValues:array<string,mixed>}
 	 */
 	public static function checkbox_values(): array {
 		return [
@@ -112,6 +118,8 @@ class FieldValues {
 
 	/**
 	 * Get `consentValue` property.
+	 *
+	 * @return array{consentValue:array<string,mixed>}
 	 */
 	public static function consent_value(): array {
 		return [
@@ -132,6 +140,8 @@ class FieldValues {
 
 	/**
 	 * Get `fileUploadValue` property.
+	 *
+	 * @return array{fileUploadValues:array<string,mixed>}
 	 */
 	public static function file_upload_values(): array {
 		return [
@@ -151,6 +161,8 @@ class FieldValues {
 
 	/**
 	 * Get `imageValues` property.
+	 *
+	 * @return array{imageValues:array<string,mixed>}
 	 */
 	public static function image_values(): array {
 		return [
@@ -196,6 +208,8 @@ class FieldValues {
 
 	/**
 	 * Get `listValues` property.
+	 *
+	 * @return array{listValues:array<string,mixed>}
 	 */
 	public static function list_values(): array {
 		return [
@@ -248,6 +262,8 @@ class FieldValues {
 
 	/**
 	 * Get `nameValues` property.
+	 *
+	 * @return array{nameValues:array<string,mixed>}
 	 */
 	public static function name_values(): array {
 		return [
@@ -273,6 +289,8 @@ class FieldValues {
 
 	/**
 	 * Get `productValues` property.
+	 *
+	 * @return array{productValues:array<string,mixed>}
 	 */
 	public static function product_values(): array {
 		return [
@@ -344,6 +362,8 @@ class FieldValues {
 
 	/**
 	 * Get `timeValues` property.
+	 *
+	 * @return array{timeValues:array<string,mixed>}
 	 */
 	public static function time_values(): array {
 		return [
@@ -377,6 +397,8 @@ class FieldValues {
 
 	/**
 	 * Get `values` property.
+	 *
+	 * @return array{values:array<string,mixed>}
 	 */
 	public static function values(): array {
 		return [
@@ -428,9 +450,11 @@ class FieldValues {
 	 *
 	 * Shim GF_Field_FileUpload::get_extra_entry_metadata().
 	 *
-	 * @param \GF_Field_FileUpload $field .
-	 * @param array                $entry .
-	 * @param array                $form .
+	 * @param \GF_Field_FileUpload    $field .
+	 * @param array<int|string,mixed> $entry .
+	 * @param array<string,mixed>     $form The form array.
+	 *
+	 * @return array<int|string,array<string,string>>
 	 */
 	protected static function get_file_upload_extra_entry_metadata( GF_Field_FileUpload $field, array $entry, array $form ): array {
 		$file_values = $entry[ $field->id ] ?? null;
@@ -502,6 +526,8 @@ class FieldValues {
 	 *
 	 * @param \GF_Field $field The gravity forms field object.
 	 * @param int       $input_key The input key that represents field's selected choice.
+	 *
+	 * @return array<string,mixed>
 	 */
 	public static function prepare_connected_choice( GF_Field $field, int $input_key ): array {
 		$type = FieldChoiceRegistry::get_type_name( $field );
@@ -517,6 +543,8 @@ class FieldValues {
 	 *
 	 * @param \GF_Field $field The gravity forms field object.
 	 * @param int       $input_key The input key that represents field's selected input.
+	 *
+	 * @return array<string,mixed>
 	 */
 	public static function prepare_connected_input( GF_Field $field, int $input_key ): array {
 		$type = FieldInputRegistry::get_type_name( $field );

--- a/src/UpdateChecker.php
+++ b/src/UpdateChecker.php
@@ -69,8 +69,8 @@ class UpdateChecker implements Hookable {
 	/**
 	 * Display notice on plugin screen.
 	 *
-	 * @param array  $plugin_data .
-	 * @param object $response .
+	 * @param array<string,mixed> $plugin_data The plugin data.
+	 * @param object              $response The response object from the update check.
 	 */
 	public static function in_plugin_update_message( array $plugin_data, $response ): void {
 		if ( empty( $response->new_version ) ) {

--- a/src/Utils/GFUtils.php
+++ b/src/Utils/GFUtils.php
@@ -262,9 +262,9 @@ class GFUtils {
 	/**
 	 * Get the draft resume URL.
 	 *
-	 * @param string $resume_token Resume token.
-	 * @param string $source_url   Source URL.
-	 * @param array  $form         Form object.
+	 * @param string              $resume_token Resume token.
+	 * @param string              $source_url   Source URL.
+	 * @param array<string,mixed> $form         Form object.
 	 *
 	 * @return string Resume URL, or empty string if no source URL was provided.
 	 */
@@ -277,7 +277,7 @@ class GFUtils {
 		 * Filters the 'Save and Continue' URL to be used with a partial entry submission.
 		 *
 		 * @param string $resume_url   The URL to be used to resume the partial entry.
-		 * @param array  $form         The Form Object.
+		 * @param array<string,mixed> $form         The Form Object.
 		 * @param string $resume_token The token that is used within the URL.
 		 * @param string $unused       Unused parameter. Included for consistency with the native
 		 *                             Gravity Forms gform_save_and_continue_resume_url hook.

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -108,7 +108,7 @@ class Utils {
 	 *
 	 * @since 0.7.0
 	 *
-	 * @return array|false
+	 * @return array<mixed>|false
 	 */
 	public static function maybe_decode_json( $value ) {
 		if ( is_array( $value ) ) {

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -3,6 +3,7 @@
 
 /**
  * Inherited Methods
+ *
  * @method void wantToTest($text)
  * @method void wantTo($text)
  * @method void execute($callable)
@@ -14,13 +15,12 @@
  * @method void comment($description)
  * @method void pause()
  *
- * @SuppressWarnings(PHPMD)
-*/
-class AcceptanceTester extends \Codeception\Actor
-{
-    use _generated\AcceptanceTesterActions;
+ * @SuppressWarnings(\PHPMD)
+ */
+class AcceptanceTester extends \Codeception\Actor {
+	use _generated\AcceptanceTesterActions;
 
-    /**
-     * Define custom actions here
-     */
+	/**
+	 * Define custom actions here
+	 */
 }

--- a/tests/_support/Factory/DraftEntry.php
+++ b/tests/_support/Factory/DraftEntry.php
@@ -14,7 +14,6 @@ use GFFormsModel;
  * Class - Entry
  */
 class DraftEntry extends \WP_UnitTest_Factory_For_Thing {
-
 	/**
 	 * Constructor
 	 *
@@ -22,6 +21,7 @@ class DraftEntry extends \WP_UnitTest_Factory_For_Thing {
 	 */
 	public function __construct( $factory = null ) {
 		parent::__construct( $factory );
+
 		$this->default_generation_definitions = [
 			'source_url'   => '',
 			'page_number'  => 1,
@@ -34,7 +34,7 @@ class DraftEntry extends \WP_UnitTest_Factory_For_Thing {
 	 *
 	 * @param array $args entry arguments.
 	 */
-	public function create_object( $args ) : string {
+	public function create_object( $args ): string {
 		$form = GFAPI::get_form( $args['form_id'] );
 
 		$entry = array_replace(
@@ -101,9 +101,8 @@ class DraftEntry extends \WP_UnitTest_Factory_For_Thing {
 	 * Gets the draft entry from an object id.
 	 *
 	 * @param string $resume_token .
-	 * @return array
 	 */
-	public function get_object_by_id( $resume_token ) : array {
+	public function get_object_by_id( $resume_token ): array {
 		return GFFormsModel::get_draft_submission_values( $resume_token );
 	}
 

--- a/tests/_support/Factory/Entry.php
+++ b/tests/_support/Factory/Entry.php
@@ -15,7 +15,6 @@ use WP_UnitTest_Generator_Sequence;
  * Class - Entry
  */
 class Entry extends \WP_UnitTest_Factory_For_Thing {
-
 	/**
 	 * Constructor
 	 *
@@ -23,6 +22,7 @@ class Entry extends \WP_UnitTest_Factory_For_Thing {
 	 */
 	public function __construct( $factory = null ) {
 		parent::__construct( $factory );
+
 		$this->default_generation_definitions = [
 			'id'       => new WP_UnitTest_Generator_Sequence( '%s' ),
 			'currency' => 'USD',
@@ -34,7 +34,7 @@ class Entry extends \WP_UnitTest_Factory_For_Thing {
 	 *
 	 * @param array $args entry arguments.
 	 */
-	public function create_object( $args ) : int {
+	public function create_object( $args ): int {
 		return GFAPI::add_entry( $args );
 	}
 

--- a/tests/_support/Factory/Field.php
+++ b/tests/_support/Factory/Field.php
@@ -7,7 +7,6 @@
 
 namespace Tests\WPGraphQL\GF\Factory;
 
-use GF_Field;
 use GF_Fields;
 use WP_UnitTest_Generator_Sequence;
 
@@ -15,7 +14,6 @@ use WP_UnitTest_Generator_Sequence;
  * Class - Field
  */
 class Field extends \WP_UnitTest_Factory_For_Thing {
-
 	/**
 	 * Constructor
 	 *
@@ -23,6 +21,7 @@ class Field extends \WP_UnitTest_Factory_For_Thing {
 	 */
 	public function __construct( $factory = null ) {
 		parent::__construct( $factory );
+
 		$this->default_generation_definitions = [
 			'id'    => new WP_UnitTest_Generator_Sequence( '%s' ),
 			'label' => new WP_UnitTest_Generator_Sequence( 'Field label %s' ),
@@ -58,8 +57,8 @@ class Field extends \WP_UnitTest_Factory_For_Thing {
 	/**
 	 * Updates a field object.
 	 *
-	 * @param GF_Field $field .
-	 * @param array    $args properties to update.
+	 * @param \GF_Field $field .
+	 * @param array     $args properties to update.
 	 */
 	public function update_object( $field, $args ) {
 		foreach ( $args as $key => $value ) {
@@ -71,7 +70,7 @@ class Field extends \WP_UnitTest_Factory_For_Thing {
 	/**
 	 * Get the field object. Returns itself.
 	 *
-	 * @param GF_Field $field .
+	 * @param \GF_Field $field .
 	 */
 	public function get_object_by_id( $field ) {
 		return $field;

--- a/tests/_support/Factory/Form.php
+++ b/tests/_support/Factory/Form.php
@@ -22,6 +22,7 @@ class Form extends \WP_UnitTest_Factory_For_Thing {
 	 */
 	public function __construct( $factory = null ) {
 		parent::__construct( $factory );
+
 		$this->default_generation_definitions = [
 			'title'       => new WP_UnitTest_Generator_Sequence( 'Form title %s' ),
 			'description' => new WP_UnitTest_Generator_Sequence( 'Form description %s' ),

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -5,6 +5,4 @@ namespace Helper;
 // all public methods declared in helper class will be available in $I
 
 class Acceptance extends \Codeception\Module {
-
-
 }

--- a/tests/_support/Helper/Functional.php
+++ b/tests/_support/Helper/Functional.php
@@ -5,6 +5,4 @@ namespace Helper;
 // all public methods declared in helper class will be available in $I
 
 class Functional extends \Codeception\Module {
-
-
 }

--- a/tests/_support/Helper/GFHelpers/ExpectedFormFields.php
+++ b/tests/_support/Helper/GFHelpers/ExpectedFormFields.php
@@ -7,25 +7,24 @@
 
 namespace Helper\GFHelpers;
 
-use WPGraphQL\GF\Type\Enum;
 use GF_Field;
 use WPGraphQL\GF\Extensions\GFChainedSelects\Type\Enum\ChainedSelectFieldAlignmentEnum;
 use WPGraphQL\GF\Extensions\GFSignature\Type\Enum\SignatureFieldBorderStyleEnum;
 use WPGraphQL\GF\Extensions\GFSignature\Type\Enum\SignatureFieldBorderWidthEnum;
+use WPGraphQL\GF\Type\Enum;
 use WPGraphQL\GF\Type\Enum\AmPmEnum;
 
 trait ExpectedFormFields {
-
-	public function add_icon_url_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'addIconUrl', ! empty( $field->addIconUrl ) ? $field->addIconUrl : static::IS_NULL );
+	public function add_icon_url_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'addIconUrl', ! empty( $field->addIconUrl ) ? $field->addIconUrl : self::IS_NULL );
 	}
 
-	public function address_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'addressType', ! empty( $field->addressType ) ? GFHelpers::get_enum_for_value( Enum\AddressFieldTypeEnum::$type, $field->addressType ) : static::IS_NULL );
+	public function address_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'addressType', ! empty( $field->addressType ) ? GFHelpers::get_enum_for_value( Enum\AddressFieldTypeEnum::$type, $field->addressType ) : self::IS_NULL );
 
-		$properties[] = $this->expectedField( 'defaultCountry', ! empty( $field->defaultCountry ) ? GFHelpers::get_enum_for_value( Enum\AddressFieldCountryEnum::$type, $field->defaultCountry ) : static::IS_NULL );
-		$properties[] = $this->expectedField( 'defaultProvince', ! empty( $field->defaultProvince ) ? GFHelpers::get_enum_for_value( Enum\AddressFieldProvinceEnum::$type, $field->defaultProvince ) : static::IS_NULL );
-		$properties[] = $this->expectedField( 'defaultState', ! empty( $field->defaultState ) ? GFHelpers::get_enum_for_value( Enum\AddressFielStateeEnum::$type, $field->defaultState ) : static::IS_NULL );
+		$properties[] = $this->expectedField( 'defaultCountry', ! empty( $field->defaultCountry ) ? GFHelpers::get_enum_for_value( Enum\AddressFieldCountryEnum::$type, $field->defaultCountry ) : self::IS_NULL );
+		$properties[] = $this->expectedField( 'defaultProvince', ! empty( $field->defaultProvince ) ? GFHelpers::get_enum_for_value( Enum\AddressFieldProvinceEnum::$type, $field->defaultProvince ) : self::IS_NULL );
+		$properties[] = $this->expectedField( 'defaultState', ! empty( $field->defaultState ) ? GFHelpers::get_enum_for_value( Enum\AddressFielStateeEnum::$type, $field->defaultState ) : self::IS_NULL );
 
 		$input_keys = [
 			'autocompleteAttribute' => 'autocompleteAttribute',
@@ -42,86 +41,86 @@ trait ExpectedFormFields {
 		$properties[] = $this->expected_inputs( $input_keys, ! empty( $field->inputs ) ? $field->inputs : [] );
 	}
 
-	public function admin_label_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'adminLabel', ! empty( $field->adminLabel ) ? $field->adminLabel : static::IS_NULL );
+	public function admin_label_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'adminLabel', ! empty( $field->adminLabel ) ? $field->adminLabel : self::IS_NULL );
 	}
 
-	public function autocomplete_setting( GF_Field $field, array &$properties ) : void {
+	public function autocomplete_setting( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->expectedField( 'hasAutocomplete', ! empty( $field->enableAutocomplete ) );
 
 		if ( ! in_array( $field->type, [ 'address', 'email', 'name' ], true ) ) {
-			$properties[] = $this->expectedField( 'autocompleteAttribute', ! empty( $field->autocompleteAttribute ) ? $field->autocompleteAttribute : static::IS_NULL );
+			$properties[] = $this->expectedField( 'autocompleteAttribute', ! empty( $field->autocompleteAttribute ) ? $field->autocompleteAttribute : self::IS_NULL );
 		}
 	}
 
-	public function background_color_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'backgroundColor', ! empty( $field->backgroundColor ) ? $field->backgroundColor : static::IS_NULL );
+	public function background_color_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'backgroundColor', ! empty( $field->backgroundColor ) ? $field->backgroundColor : self::IS_NULL );
 	}
 
-	public function base_price_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'price', ! empty( $field->basePrice ) ? floatval( preg_replace( '/[^\d\.]/', '', $field->basePrice ) ) : static::IS_NULL );
-		$properties[] = $this->expectedField( 'formattedPrice', ! empty( $field->basePrice ) ? $field->basePrice : static::IS_NULL );
+	public function base_price_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'price', ! empty( $field->basePrice ) ? floatval( preg_replace( '/[^\d\.]/', '', $field->basePrice ) ) : self::IS_NULL );
+		$properties[] = $this->expectedField( 'formattedPrice', ! empty( $field->basePrice ) ? $field->basePrice : self::IS_NULL );
 	}
 
-	public function border_color_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'borderColor', ! empty( $field->borderColor ) ? $field->borderColor : static::IS_NULL );
+	public function border_color_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'borderColor', ! empty( $field->borderColor ) ? $field->borderColor : self::IS_NULL );
 	}
 
-	public function border_style_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'borderStyle', ! empty( $field->borderStyle ) ? GFHelpers::get_enum_for_value( SignatureFieldBorderStyleEnum::$type, $field->borderStyle ) : static::IS_NULL );
+	public function border_style_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'borderStyle', ! empty( $field->borderStyle ) ? GFHelpers::get_enum_for_value( SignatureFieldBorderStyleEnum::$type, $field->borderStyle ) : self::IS_NULL );
 	}
 
-	public function border_width_setting( GF_Field $field, array &$properties ) : void {
+	public function border_width_setting( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->expectedField( 'borderWidth', GFHelpers::get_enum_for_value( SignatureFieldBorderWidthEnum::$type, $field->borderWidth ?? 0 ) );
 	}
 
-	public function box_width_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'boxWidth', isset( $field->boxWidth ) ? (int) $field->boxWidth : static::IS_NULL );
+	public function box_width_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'boxWidth', isset( $field->boxWidth ) ? (int) $field->boxWidth : self::IS_NULL );
 	}
 
-	public function calculation_setting( GF_Field $field, array &$properties ) : void {
+	public function calculation_setting( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->expectedField( 'isCalculation', ! empty( $field->enableCalculation ) );
-		$properties[] = $this->expectedField( 'calculationFormula', ! empty( $field->calculationFormula ) ? $field->calculationFormula : static::IS_NULL );
-		$properties[] = $this->expectedField( 'calculationRounding', isset( $field->calculationRounding ) ? (int) $field->calculationRounding : static::IS_NULL );
+		$properties[] = $this->expectedField( 'calculationFormula', ! empty( $field->calculationFormula ) ? $field->calculationFormula : self::IS_NULL );
+		$properties[] = $this->expectedField( 'calculationRounding', isset( $field->calculationRounding ) ? (int) $field->calculationRounding : self::IS_NULL );
 	}
 
-	public function captcha_badge_setting( GF_Field $field, array &$properties ) : void {
+	public function captcha_badge_setting( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->expectedField( 'captchaBadgePosition', GFHelpers::get_enum_for_value( Enum\CaptchaFieldBadgePositionEnum::$type, $field->captchaBadge ?? 'bottomright' ) );
 	}
 
-	public function captcha_bg_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'simpleCaptchaBackgroundColor', ! empty( $field->simpleCaptchaBackgroundColor ) ? $field->simpleCaptchaBackgroundColor : static::IS_NULL );
+	public function captcha_bg_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'simpleCaptchaBackgroundColor', ! empty( $field->simpleCaptchaBackgroundColor ) ? $field->simpleCaptchaBackgroundColor : self::IS_NULL );
 	}
 
-	public function captcha_fg_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'simpleCaptchaFontColor', ! empty( $field->simpleCaptchaFontColor ) ? $field->simpleCaptchaFontColor : static::IS_NULL );
+	public function captcha_fg_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'simpleCaptchaFontColor', ! empty( $field->simpleCaptchaFontColor ) ? $field->simpleCaptchaFontColor : self::IS_NULL );
 	}
 
-	public function captcha_language_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'captchaLanguage', ! empty( $field->captchaLanguage ) ? $field->captchaLanguage : static::IS_NULL );
+	public function captcha_language_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'captchaLanguage', ! empty( $field->captchaLanguage ) ? $field->captchaLanguage : self::IS_NULL );
 	}
 
-	public function captcha_size_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'simpleCaptchaSize', ! empty( $field->simpleCaptchaSize ) ? GFHelpers::get_enum_for_value( Enum\FormFieldSizeEnum::$type, $field->simpleCaptchaSize ) : static::IS_NULL );
+	public function captcha_size_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'simpleCaptchaSize', ! empty( $field->simpleCaptchaSize ) ? GFHelpers::get_enum_for_value( Enum\FormFieldSizeEnum::$type, $field->simpleCaptchaSize ) : self::IS_NULL );
 	}
 
-	public function captcha_theme_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'captchaTheme', ! empty( $field->captchaTheme ) ? GFHelpers::get_enum_for_value( Enum\CaptchaFieldThemeEnum::$type, $field->captchaTheme ) : static::IS_NULL );
+	public function captcha_theme_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'captchaTheme', ! empty( $field->captchaTheme ) ? GFHelpers::get_enum_for_value( Enum\CaptchaFieldThemeEnum::$type, $field->captchaTheme ) : self::IS_NULL );
 	}
 
-	public function captcha_type_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'captchaType', ! empty( $field->captchaType ) ? GFHelpers::get_enum_for_value( Enum\CaptchaFieldTypeEnum::$type, $field->captchaType ) : static::IS_NULL );
+	public function captcha_type_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'captchaType', ! empty( $field->captchaType ) ? GFHelpers::get_enum_for_value( Enum\CaptchaFieldTypeEnum::$type, $field->captchaType ) : self::IS_NULL );
 	}
 
-	public function chained_selects_alignment_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'chainedSelectsAlignment', ! empty( $field->chainedSelectsAlignment ) ? GFHelpers::get_enum_for_value( ChainedSelectFieldAlignmentEnum::$type, $field->chainedSelectsAlignment ) : static::IS_NULL );
+	public function chained_selects_alignment_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'chainedSelectsAlignment', ! empty( $field->chainedSelectsAlignment ) ? GFHelpers::get_enum_for_value( ChainedSelectFieldAlignmentEnum::$type, $field->chainedSelectsAlignment ) : self::IS_NULL );
 	}
 
-	public function chained_selects_hide_inactive_setting( GF_Field $field, array &$properties ) : void {
+	public function chained_selects_hide_inactive_setting( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->expectedField( 'shouldHideInactiveChoices', ! empty( $field->chainedSelectsHideInactive ) );
 	}
 
-	public function choices_setting( GF_Field $field, array &$properties ) : void {
+	public function choices_setting( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->expectedField( 'hasChoiceValue', ! empty( $field->enableChoiceValue ) );
 
 		$keys = [
@@ -138,7 +137,7 @@ trait ExpectedFormFields {
 		$properties[] = $this->expected_choices( $keys, ! empty( $field->choices ) ? $field->choices : [] );
 	}
 
-	public function chained_choices_setting( GF_Field $field, array &$properties ) : void {
+	public function chained_choices_setting( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->expectedField( 'hasChoiceValue', ! empty( $field->enableChoiceValue ) );
 
 		$choice_keys  = [
@@ -157,7 +156,7 @@ trait ExpectedFormFields {
 		$properties[] = $this->expected_inputs( $input_keys, ! empty( $field->inputs ) ? $field->inputs : [] );
 	}
 
-	public function columns_setting( GF_Field $field, array &$properties ) : void {
+	public function columns_setting( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->expectedField( 'hasColumns', ! empty( $field->enableColumns ) );
 
 		$choice_keys  = [
@@ -167,26 +166,26 @@ trait ExpectedFormFields {
 		$properties[] = $this->expected_choices( $choice_keys, ! empty( $field->choices ) ? $field->choices : [] );
 	}
 
-	public function conditional_logic_field_setting( GF_Field $field, array &$properties ) : void {
+	public function conditional_logic_field_setting( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->get_expected_conditional_logic_fields( $field->conditionalLogic );
 	}
 
-	public function conditional_logic_page_setting( GF_Field $field, array &$properties ) : void {
+	public function conditional_logic_page_setting( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->get_expected_conditional_logic_fields( $field->conditionalLogic );
 	}
 
-	public function content_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'content', ! empty( $field->content ) ? $field->content : static::IS_NULL );
+	public function content_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'content', ! empty( $field->content ) ? $field->content : self::IS_NULL );
 	}
 
-	public function copy_values_option( GF_Field $field, array &$properties ) : void {
+	public function copy_values_option( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->expectedField( 'shouldCopyValuesOption', ! empty( $field->enableCopyValuesOption ) );
-		$properties[] = $this->expectedField( 'copyValuesOptionFieldId', isset( $field->copyValuesOptionField ) ? (int) $field->copyValuesOptionField : static::IS_NULL );
-		$properties[] = $this->expectedField( 'copyValuesOptionLabel', ! empty( $field->copyValuesOptionLabel ) ? $field->copyValuesOptionLabel : static::IS_NULL );
+		$properties[] = $this->expectedField( 'copyValuesOptionFieldId', isset( $field->copyValuesOptionField ) ? (int) $field->copyValuesOptionField : self::IS_NULL );
+		$properties[] = $this->expectedField( 'copyValuesOptionLabel', ! empty( $field->copyValuesOptionLabel ) ? $field->copyValuesOptionLabel : self::IS_NULL );
 	}
 
-	public function credit_card_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'supportedCreditCards', ! empty( $field->creditCards ) ? $field->creditCards : static::IS_NULL );
+	public function credit_card_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'supportedCreditCards', ! empty( $field->creditCards ) ? $field->creditCards : self::IS_NULL );
 
 		$keys = [
 			'customLabel' => 'customLabel',
@@ -198,12 +197,12 @@ trait ExpectedFormFields {
 		$properties[] = $this->expected_inputs( $keys, ! empty( $field->inputs ) ? $field->inputs : [] );
 	}
 
-	public function css_class_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'cssClass', ! empty( $field->cssClass ) ? $field->cssClass : static::IS_NULL );
+	public function css_class_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'cssClass', ! empty( $field->cssClass ) ? $field->cssClass : self::IS_NULL );
 	}
 
-	public function date_format_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'dateFormat', ! empty( $field->dateFormat ) ? GFHelpers::get_enum_for_value( Enum\DateFieldFormatEnum::$type, $field->dateFormat ) : static::IS_NULL );
+	public function date_format_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'dateFormat', ! empty( $field->dateFormat ) ? GFHelpers::get_enum_for_value( Enum\DateFieldFormatEnum::$type, $field->dateFormat ) : self::IS_NULL );
 
 		$keys = [
 			'autocompleteAttribute' => 'autocompleteAttribute',
@@ -217,40 +216,40 @@ trait ExpectedFormFields {
 		$properties[] = $this->expected_inputs( $keys, ! empty( $field->inputs ) ? $field->inputs : [] );
 	}
 
-	public function date_input_type_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'dateType', ! empty( $field->dateType ) ? GFHelpers::get_enum_for_value( Enum\DateFieldTypeEnum::$type, $field->dateType ) : static::IS_NULL );
-		$properties[] = $this->expectedField( 'calendarIconType', ! empty( $field->calendarIconType ) ? GFHelpers::get_enum_for_value( Enum\FormFieldCalendarIconTypeEnum::$type, $field->calendarIconType ) : static::IS_NULL );
-		$properties[] = $this->expectedField( 'calendarIconUrl', ! empty( $field->calendarIconUrl ) ? $field->calendarIconUrl : static::IS_NULL );
+	public function date_input_type_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'dateType', ! empty( $field->dateType ) ? GFHelpers::get_enum_for_value( Enum\DateFieldTypeEnum::$type, $field->dateType ) : self::IS_NULL );
+		$properties[] = $this->expectedField( 'calendarIconType', ! empty( $field->calendarIconType ) ? GFHelpers::get_enum_for_value( Enum\FormFieldCalendarIconTypeEnum::$type, $field->calendarIconType ) : self::IS_NULL );
+		$properties[] = $this->expectedField( 'calendarIconUrl', ! empty( $field->calendarIconUrl ) ? $field->calendarIconUrl : self::IS_NULL );
 	}
 
-	public function default_value_setting( GF_Field $field, array &$properties ) : void {
+	public function default_value_setting( GF_Field $field, array &$properties ): void {
 		if ( 'email' !== $field->type ) {
-			$properties[] = $this->expectedField( 'defaultValue', ! empty( $field->defaultValue ) ? $field->defaultValue : static::IS_NULL );
+			$properties[] = $this->expectedField( 'defaultValue', ! empty( $field->defaultValue ) ? $field->defaultValue : self::IS_NULL );
 		}
 	}
 
-	public function default_value_textarea_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'defaultValue', ! empty( $field->defaultValue ) ? $field->defaultValue : static::IS_NULL );
+	public function default_value_textarea_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'defaultValue', ! empty( $field->defaultValue ) ? $field->defaultValue : self::IS_NULL );
 	}
 
-	public function delete_icon_url_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'deleteIconUrl', ! empty( $field->deleteIconUrl ) ? $field->deleteIconUrl : static::IS_NULL );
+	public function delete_icon_url_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'deleteIconUrl', ! empty( $field->deleteIconUrl ) ? $field->deleteIconUrl : self::IS_NULL );
 	}
 
-	public function description_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'description', ! empty( $field->description ) ? $field->description : static::IS_NULL );
-		$properties[] = $this->expectedField( 'descriptionPlacement', ! empty( $field->descriptionPlacement ) ? GFHelpers::get_enum_for_value( Enum\FormFieldDescriptionPlacementEnum::$type, $field->descriptionPlacement ) : static::IS_NULL );
+	public function description_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'description', ! empty( $field->description ) ? $field->description : self::IS_NULL );
+		$properties[] = $this->expectedField( 'descriptionPlacement', ! empty( $field->descriptionPlacement ) ? GFHelpers::get_enum_for_value( Enum\FormFieldDescriptionPlacementEnum::$type, $field->descriptionPlacement ) : self::IS_NULL );
 	}
 
-	public function disable_margins_setting( GF_Field $field, array &$properties ) : void {
+	public function disable_margins_setting( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->expectedField( 'hasMargins', empty( $field->disableMargins ) );
 	}
 
-	public function duplicate_setting( GF_Field $field, array &$properties ) : void {
+	public function duplicate_setting( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->expectedField( 'shouldAllowDuplicates', empty( $field->noDuplicates ) );
 	}
 
-	public function email_confirm_setting( GF_Field $field, array &$properties ) : void {
+	public function email_confirm_setting( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->expectedField( 'hasEmailConfirmation', ! empty( $field->emailConfirmEnabled ) );
 
 		$keys = [
@@ -266,28 +265,27 @@ trait ExpectedFormFields {
 		$properties[] = $this->expected_inputs( $keys, ! empty( $field->inputs ) ? $field->inputs : [] );
 	}
 
-
-	public function enable_enhanced_ui_setting( GF_Field $field, array &$properties ) : void {
+	public function enable_enhanced_ui_setting( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->expectedField( 'hasEnhancedUI', ! empty( $field->enableEnhancedUI ) );
 	}
 
-	public function error_message_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'errorMessage', ! empty( $field->errorMessage ) ? $field->errorMessage : static::IS_NULL );
+	public function error_message_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'errorMessage', ! empty( $field->errorMessage ) ? $field->errorMessage : self::IS_NULL );
 	}
 
-	public function file_extensions_setting( GF_Field $field, array &$properties ) : void {
+	public function file_extensions_setting( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->expectedField( 'allowedExtensions', explode( ',', $field->allowedExtensions ) );
 	}
 
-	public function file_size_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'maxFileSize', ! empty( $field->maxFileSize ) ? $field->maxFileSize : static::IS_NULL );
+	public function file_size_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'maxFileSize', ! empty( $field->maxFileSize ) ? $field->maxFileSize : self::IS_NULL );
 	}
 
-	public function force_ssl_field_setting( GF_Field $field, array &$properties ) : void {
+	public function force_ssl_field_setting( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->expectedField( 'isSSLForced', ! empty( $field->forceSSL ) );
 	}
 
-	public function gquiz_setting_choices( GF_Field $field, array &$properties ) : void {
+	public function gquiz_setting_choices( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->expectedField( 'hasWeightedScore', ! empty( $field->gquizWeightedScoreEnabled ) );
 
 		$keys = [
@@ -299,46 +297,46 @@ trait ExpectedFormFields {
 		$properties[] = $this->expected_choices( $keys, ! empty( $field->choices ) ? $field->choices : [] );
 	}
 
-	public function gquiz_setting_show_answer_explanation( GF_Field $field, array &$properties ) : void {
+	public function gquiz_setting_show_answer_explanation( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->expectedField( 'shouldShowAnswerExplanation', ! empty( $field->gquizShowAnswerExplanation ) );
-		$properties[] = $this->expectedField( 'answerExplanation', ! empty( $field->gquizAnswerExplanation ) ? $field->gquizAnswerExplanation : static::IS_NULL );
+		$properties[] = $this->expectedField( 'answerExplanation', ! empty( $field->gquizAnswerExplanation ) ? $field->gquizAnswerExplanation : self::IS_NULL );
 	}
 
-	public function gquiz_setting_randomize_quiz_choices( GF_Field $field, array &$properties ) : void {
+	public function gquiz_setting_randomize_quiz_choices( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->expectedField( 'shouldRandomizeQuizChoices', ! empty( $field->gquizEnableRandomizeQuizChoices ) );
 	}
 
-	public function gquiz_setting_question( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'label', ! empty( $field->label ) ? $field->label : static::IS_NULL );
+	public function gquiz_setting_question( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'label', ! empty( $field->label ) ? $field->label : self::IS_NULL );
 	}
 
-	public function input_mask_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'inputMaskValue', ! empty( $field->inputMaskValue ) ? $field->inputMaskValue : static::IS_NULL );
+	public function input_mask_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'inputMaskValue', ! empty( $field->inputMaskValue ) ? $field->inputMaskValue : self::IS_NULL );
 		$properties[] = $this->expectedField( 'hasInputMask', ! empty( $field->inputMask ) );
 	}
 
-	public function label_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'label', ! empty( $field->label ) ? $field->label : static::IS_NULL );
+	public function label_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'label', ! empty( $field->label ) ? $field->label : self::IS_NULL );
 	}
 
-	public function label_placement_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'labelPlacement', ! empty( $field->labelPlacement ) ? GFHelpers::get_enum_for_value( Enum\FormFieldLabelPlacementEnum::$type, $field->labelPlacement ) : static::IS_NULL );
+	public function label_placement_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'labelPlacement', ! empty( $field->labelPlacement ) ? GFHelpers::get_enum_for_value( Enum\FormFieldLabelPlacementEnum::$type, $field->labelPlacement ) : self::IS_NULL );
 	}
 
-	public function maxlen_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'maxLength', isset( $field->maxLength ) ? (int) $field->maxLength : static::IS_NULL );
+	public function maxlen_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'maxLength', isset( $field->maxLength ) ? (int) $field->maxLength : self::IS_NULL );
 	}
 
-	public function maxrows_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'maxRows', isset( $field->maxRows ) ? (int) $field->maxRows : static::IS_NULL );
+	public function maxrows_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'maxRows', isset( $field->maxRows ) ? (int) $field->maxRows : self::IS_NULL );
 	}
 
-	public function multiple_files_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'maxFiles', isset( $field->maxFiles ) ? (int) $field->maxFiles : static::IS_NULL );
+	public function multiple_files_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'maxFiles', isset( $field->maxFiles ) ? (int) $field->maxFiles : self::IS_NULL );
 		$properties[] = $this->expectedField( 'canAcceptMultipleFiles', ! empty( $field->multipleFiles ) );
 	}
 
-	public function name_setting( GF_Field $field, array &$properties ) : void {
+	public function name_setting( GF_Field $field, array &$properties ): void {
 		$input_keys = [
 			'autocompleteAttribute' => 'autocompleteAttribute',
 			'defaultValue'          => 'defaultValue',
@@ -362,23 +360,23 @@ trait ExpectedFormFields {
 		$properties[] = $this->expected_choices( $choice_keys, ! empty( $field->choices ) ? $field->choices : [] );
 	}
 
-	public function next_button_setting( GF_Field $field, array &$properties ) : void {
+	public function next_button_setting( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->expectedObject(
 			'nextButton',
 			[
-				$this->expectedField( 'type', ! empty( $field->nextButton['type'] ) ? GFHelpers::get_enum_for_value( Enum\FormButtonTypeEnum::$type, $field->nextButton['type'] ) : static::IS_NULL ),
-				$this->expectedField( 'text', ! empty( $field->nextButton['text'] ) ? $field->nextButton['text'] : static::IS_NULL ),
-				$this->expectedField( 'imageUrl', ! empty( $field->nextButton['imageUrl'] ) ? $field->nextButton['imageUrl'] : static::IS_NULL ),
+				$this->expectedField( 'type', ! empty( $field->nextButton['type'] ) ? GFHelpers::get_enum_for_value( Enum\FormButtonTypeEnum::$type, $field->nextButton['type'] ) : self::IS_NULL ),
+				$this->expectedField( 'text', ! empty( $field->nextButton['text'] ) ? $field->nextButton['text'] : self::IS_NULL ),
+				$this->expectedField( 'imageUrl', ! empty( $field->nextButton['imageUrl'] ) ? $field->nextButton['imageUrl'] : self::IS_NULL ),
 				$this->get_expected_conditional_logic_fields( ! empty( $field->nextButton['conditionalLogic'] ) ? $field->nextButton['conditionalLogic'] : [] ),
 			]
 		);
 	}
 
-	public function number_format_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'numberFormat', ! empty( $field->numberFormat ) ? GFHelpers::get_enum_for_value( Enum\NumberFieldFormatEnum::$type, $field->numberFormat ) : static::IS_NULL );
+	public function number_format_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'numberFormat', ! empty( $field->numberFormat ) ? GFHelpers::get_enum_for_value( Enum\NumberFieldFormatEnum::$type, $field->numberFormat ) : self::IS_NULL );
 	}
 
-	public function other_choice_setting( GF_Field $field, array &$properties ) : void {
+	public function other_choice_setting( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->expectedField( 'hasOtherChoice', ! empty( $field->enableOtherChoice ) );
 
 		if ( 'quiz' === $field->type ) {
@@ -386,11 +384,11 @@ trait ExpectedFormFields {
 		}
 	}
 
-	public function password_field_setting( GF_Field $field, array &$properties ) : void {
+	public function password_field_setting( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->expectedField( 'isPasswordInput', ! empty( $field->enablePasswordInput ) );
 	}
 
-	public function password_setting( GF_Field $field, array &$properties ) : void {
+	public function password_setting( GF_Field $field, array &$properties ): void {
 		$keys = [
 			'customLabel' => 'customLabel',
 			'id'          => 'id',
@@ -402,52 +400,52 @@ trait ExpectedFormFields {
 		$properties[] = $this->expected_inputs( $keys, ! empty( $field->inputs ) ? $field->inputs : [] );
 	}
 
-	public function password_strength_setting( GF_Field $field, array &$properties ) : void {
+	public function password_strength_setting( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->expectedField( 'hasPasswordStrengthIndicator', ! empty( $field->passwordStrengthEnabled ) );
-		$properties[] = $this->expectedField( 'minPasswordStrength', ! empty( $field->minPasswordStrength ) ? GFHelpers::get_enum_for_value( Enum\PasswordFieldMinStrengthEnum::$type, $field->minPasswordStrength ) : static::IS_NULL );
+		$properties[] = $this->expectedField( 'minPasswordStrength', ! empty( $field->minPasswordStrength ) ? GFHelpers::get_enum_for_value( Enum\PasswordFieldMinStrengthEnum::$type, $field->minPasswordStrength ) : self::IS_NULL );
 	}
 
-	public function password_visibility_setting( GF_Field $field, array &$properties ) : void {
+	public function password_visibility_setting( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->expectedField( 'hasPasswordVisibilityToggle', ! empty( $field->passwordVisibilityEnabled ) );
 	}
 
-	public function pen_color_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'penColor', ! empty( $field->penColor ) ? $field->penColor : static::IS_NULL );
+	public function pen_color_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'penColor', ! empty( $field->penColor ) ? $field->penColor : self::IS_NULL );
 	}
 
-	public function pen_size_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'penSize', ! empty( $field->penSize ) ? $field->penSize : static::IS_NULL );
+	public function pen_size_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'penSize', ! empty( $field->penSize ) ? $field->penSize : self::IS_NULL );
 	}
 
-	public function phone_format_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'phoneFormat', ! empty( $field->phoneFormat ) ? GFHelpers::get_enum_for_value( Enum\PhoneFieldFormatEnum::$type, $field->phoneFormat ) : static::IS_NULL );
+	public function phone_format_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'phoneFormat', ! empty( $field->phoneFormat ) ? GFHelpers::get_enum_for_value( Enum\PhoneFieldFormatEnum::$type, $field->phoneFormat ) : self::IS_NULL );
 	}
 
-	public function placeholder_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'placeholder', ! empty( $field->placeholder ) ? $field->placeholder : static::IS_NULL );
+	public function placeholder_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'placeholder', ! empty( $field->placeholder ) ? $field->placeholder : self::IS_NULL );
 	}
 
-	public function placeholder_textarea_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'placeholder', ! empty( $field->placeholder ) ? $field->placeholder : static::IS_NULL );
+	public function placeholder_textarea_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'placeholder', ! empty( $field->placeholder ) ? $field->placeholder : self::IS_NULL );
 	}
 
-	public function post_category_checkbox_setting( GF_Field $field, array &$properties ) : void {
+	public function post_category_checkbox_setting( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->expectedField( 'hasAllCategories', ! empty( $field->displayAllCategories ) );
 	}
 
-	public function post_category_initial_item_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'dropdownPlaceholder', ! empty( $field->categoryInitialItem ) ? $field->categoryInitialItem : static::IS_NULL );
+	public function post_category_initial_item_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'dropdownPlaceholder', ! empty( $field->categoryInitialItem ) ? $field->categoryInitialItem : self::IS_NULL );
 	}
 
-	public function post_custom_field_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'postCustomFieldName', ! empty( $field->postCustomFieldName ) ? $field->postCustomFieldName : static::IS_NULL );
+	public function post_custom_field_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'postCustomFieldName', ! empty( $field->postCustomFieldName ) ? $field->postCustomFieldName : self::IS_NULL );
 	}
 
-	public function post_image_featured_image( GF_Field $field, array &$properties ) : void {
+	public function post_image_featured_image( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->expectedField( 'isFeaturedImage', ! empty( $field->postFeaturedImage ) );
 	}
 
-	public function post_image_setting( GF_Field $field, array &$properties ) : void {
+	public function post_image_setting( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->expectedField( 'allowedExtensions', explode( ',', $field->allowedExtensions ) );
 		$properties[] = $this->expectedField( 'hasAlt', ! empty( $field->displayAlt ) );
 		$properties[] = $this->expectedField( 'hasCaption', ! empty( $field->displayCaption ) );
@@ -455,49 +453,48 @@ trait ExpectedFormFields {
 		$properties[] = $this->expectedField( 'hasTitle', ! empty( $field->displayTitle ) );
 	}
 
-	public function prepopulate_field_setting( GF_Field $field, array &$properties ) : void {
+	public function prepopulate_field_setting( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->expectedField( 'canPrepopulate', ! empty( $field->allowsPrepopulate ) );
 
 		if ( ( empty( $field->inputs ) && ! in_array( $field->type, [ 'date', 'email', 'time', 'password' ], true ) ) || 'checkbox' === $field->type ) {
-			$properties[] = $this->expectedField( 'inputName', ! empty( $field->inputName ) ? $field->inputName : static::IS_NULL );
+			$properties[] = $this->expectedField( 'inputName', ! empty( $field->inputName ) ? $field->inputName : self::IS_NULL );
 		}
 	}
 
-
-	public function previous_button_setting( GF_Field $field, array &$properties ) : void {
+	public function previous_button_setting( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->expectedObject(
 			'previousButton',
 			[
-				$this->expectedField( 'type', ! empty( $field->previousButton['type'] ) ? GFHelpers::get_enum_for_value( Enum\FormButtonTypeEnum::$type, $field->previousButton['type'] ) : static::IS_NULL ),
-				$this->expectedField( 'text', ! empty( $field->previousButton['text'] ) ? $field->previousButton['text'] : static::IS_NULL ),
-				$this->expectedField( 'imageUrl', ! empty( $field->previousButton['imageUrl'] ) ? $field->previousButton['imageUrl'] : static::IS_NULL ),
+				$this->expectedField( 'type', ! empty( $field->previousButton['type'] ) ? GFHelpers::get_enum_for_value( Enum\FormButtonTypeEnum::$type, $field->previousButton['type'] ) : self::IS_NULL ),
+				$this->expectedField( 'text', ! empty( $field->previousButton['text'] ) ? $field->previousButton['text'] : self::IS_NULL ),
+				$this->expectedField( 'imageUrl', ! empty( $field->previousButton['imageUrl'] ) ? $field->previousButton['imageUrl'] : self::IS_NULL ),
 				$this->get_expected_conditional_logic_fields( ! empty( $field->previousButton['conditionalLogic'] ) ? $field->previousButton['conditionalLogic'] : [] ),
 			]
 		);
 	}
 
-	public function product_field_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'productField', isset( $field->productField ) ? (int) $field->productField : static::IS_NULL );
+	public function product_field_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'productField', isset( $field->productField ) ? (int) $field->productField : self::IS_NULL );
 	}
 
-	public function range_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'rangeMax', isset( $field->rangeMax ) ? (float) $field->rangeMax : static::IS_NULL );
-		$properties[] = $this->expectedField( 'rangeMin', isset( $field->rangeMin ) ? (float) $field->rangeMin : static::IS_NULL );
+	public function range_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'rangeMax', isset( $field->rangeMax ) ? (float) $field->rangeMax : self::IS_NULL );
+		$properties[] = $this->expectedField( 'rangeMin', isset( $field->rangeMin ) ? (float) $field->rangeMin : self::IS_NULL );
 	}
 
-	public function rich_text_editor_setting( GF_Field $field, array &$properties ) : void {
+	public function rich_text_editor_setting( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->expectedField( 'hasRichTextEditor', ! empty( $field->useRichTextEditor ) );
 	}
 
-	public function rules_setting( GF_Field $field, array &$properties ) : void {
+	public function rules_setting( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->expectedField( 'isRequired', ! empty( $field->isRequired ) );
 	}
 
-	public function size_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'size', ! empty( $field->size ) ? GFHelpers::get_enum_for_value( Enum\FormFieldSizeEnum::$type, $field->size ) : static::IS_NULL );
+	public function size_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'size', ! empty( $field->size ) ? GFHelpers::get_enum_for_value( Enum\FormFieldSizeEnum::$type, $field->size ) : self::IS_NULL );
 	}
 
-	public function select_all_choices_setting( GF_Field $field, array &$properties ) : void {
+	public function select_all_choices_setting( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->expectedField( 'hasSelectAll', ! empty( $field->enableSelectAll ) );
 
 		$keys = [
@@ -509,12 +506,12 @@ trait ExpectedFormFields {
 		$properties[] = $this->expected_inputs( $keys, ! empty( $field->inputs ) ? $field->inputs : [] );
 	}
 
-	public function sub_label_placement_setting( GF_Field $field, array &$properties ) : void {
+	public function sub_label_placement_setting( GF_Field $field, array &$properties ): void {
 		$properties[] = $this->expectedField( 'subLabelPlacement', GFHelpers::get_enum_for_value( Enum\FormFieldSubLabelPlacementEnum::$type, ! empty( $field->subLabelPlacement ) ? $field->subLabelPlacement : 'inherit' ) );
 	}
 
-	public function time_format_setting( GF_Field $field, array &$properties ) : void {
-		$properties[] = $this->expectedField( 'timeFormat', ! empty( $field->timeFormat ) ? GFHelpers::get_enum_for_value( Enum\TimeFieldFormatEnum::$type, $field->timeFormat ) : static::IS_NULL );
+	public function time_format_setting( GF_Field $field, array &$properties ): void {
+		$properties[] = $this->expectedField( 'timeFormat', ! empty( $field->timeFormat ) ? GFHelpers::get_enum_for_value( Enum\TimeFieldFormatEnum::$type, $field->timeFormat ) : self::IS_NULL );
 
 		$keys = [
 			'autocompleteAtribute' => 'autocompleteAtribute',
@@ -528,10 +525,10 @@ trait ExpectedFormFields {
 		$properties[] = $this->expected_inputs( $keys, ! empty( $field->inputs ) ? $field->inputs : [] );
 	}
 
-	public function expected_choices( array $keys, array $choices ) : ?array {
+	public function expected_choices( array $keys, array $choices ): ?array {
 		$expected_nodes = [];
 		if ( empty( $choices ) ) {
-			return $this->expectedField( 'choices', static::IS_NULL );
+			return $this->expectedField( 'choices', self::IS_NULL );
 		}
 
 		foreach ( $choices as $index => $choice ) {
@@ -540,7 +537,7 @@ trait ExpectedFormFields {
 			foreach ( $keys as $name => $key ) {
 				switch ( $name ) {
 					case 'price':
-						$expected_fields[] = $this->expectedField( $name, ! empty( $choice['price'] ) ? floatval( preg_replace( '/[^\d\.]/', '', $choice['price'] ) ) : static::IS_NULL );
+						$expected_fields[] = $this->expectedField( $name, ! empty( $choice['price'] ) ? floatval( preg_replace( '/[^\d\.]/', '', $choice['price'] ) ) : self::IS_NULL );
 						break;
 					case 'choices':
 						$expected_fields[] = $this->expected_choices( $keys, $choice['choices'] ?? [] );
@@ -549,7 +546,7 @@ trait ExpectedFormFields {
 						$expected_fields[] = $this->expectedField( $name, (string) $choice[ $key ] );
 						break;
 					default:
-						$expected_fields[] = $this->expectedField( $name, $choice[ $key ] ?? static::IS_NULL );
+						$expected_fields[] = $this->expectedField( $name, $choice[ $key ] ?? self::IS_NULL );
 						break;
 				}
 			}
@@ -566,24 +563,24 @@ trait ExpectedFormFields {
 		);
 	}
 
-	public function expected_inputs( array $keys, array $inputs ) : array {
+	public function expected_inputs( array $keys, array $inputs ): array {
 		$expected_nodes = [];
 		foreach ( $inputs as $index => $input ) {
 			$expected_fields = [];
 			foreach ( $keys as $name => $key ) {
 				switch ( $name ) {
 					case 'id':
-						$expected_fields[] = $this->expectedField( $name, isset( $input[ $key ] ) ? (float) $input[ $key ] : static::IS_NULL );
+						$expected_fields[] = $this->expectedField( $name, isset( $input[ $key ] ) ? (float) $input[ $key ] : self::IS_NULL );
 						break;
 					case 'defaultValue':
-						$expected_fields[] = $this->expectedField( $name, isset( $input[ $key ] ) ? (string) $input[ $key ] : static::IS_NULL );
+						$expected_fields[] = $this->expectedField( $name, isset( $input[ $key ] ) ? (string) $input[ $key ] : self::IS_NULL );
 						break;
 					case 'hasChoiceValue':
 					case 'isHidden':
 						$expected_fields[] = $this->expectedField( $name, ! empty( $input[ $key ] ) );
 						break;
 					default:
-						$expected_fields[] = $this->expectedField( $name, isset( $input[ $key ] ) ? $input[ $key ] : static::IS_NULL );
+						$expected_fields[] = $this->expectedField( $name, isset( $input[ $key ] ) ? $input[ $key ] : self::IS_NULL );
 				}
 			}
 
@@ -601,7 +598,7 @@ trait ExpectedFormFields {
 
 	public function expected_field_value( string $key, $values ) {
 		if ( null === $values ) {
-			return $this->expectedField( $key, static::IS_NULL );
+			return $this->expectedField( $key, self::IS_NULL );
 		}
 
 		if ( is_array( $values ) ) {
@@ -609,27 +606,27 @@ trait ExpectedFormFields {
 			foreach ( $values as $name => $value ) {
 				switch ( $value ) {
 					case 'codecept_field_value_is_null':
-						$value = static::IS_NULL;
+						$value = self::IS_NULL;
 						break;
 					case 'codecept_field_value_not_null':
-						$value = static::NOT_NULL;
+						$value = self::NOT_NULL;
 						break;
 					case 'codecept_field_value_not_falsy':
-						$value = static::NOT_FALSY;
+						$value = self::NOT_FALSY;
 						break;
 					case 'codecept_field_value_is_falsy':
-						$value = static::IS_FALSY;
+						$value = self::IS_FALSY;
 						break;
 				}
 				switch ( (string) $name ) {
 					case 'amPm':
-						$expected[] = $this->expectedField( $name, isset( $value ) ? GFHelpers::get_enum_for_value( AmPmEnum::$type, $value ) : static::IS_NULL );
+						$expected[] = $this->expectedField( $name, isset( $value ) ? GFHelpers::get_enum_for_value( AmPmEnum::$type, $value ) : self::IS_NULL );
 						break;
 					case 'url':
-						$expected[] = $this->expectedField( $name, ! empty( $value ) ? static::NOT_FALSY : static::IS_NULL );
+						$expected[] = $this->expectedField( $name, ! empty( $value ) ? self::NOT_FALSY : self::IS_NULL );
 						break;
 					case 'basePath':
-						$expected[] = $this->expectedField( $name, $this->is_draft ? static::IS_NULL : static::NOT_FALSY );
+						$expected[] = $this->expectedField( $name, $this->is_draft ? self::IS_NULL : self::NOT_FALSY );
 						break;
 					default:
 						$expected[] = $this->expectedField( $name, $value );

--- a/tests/_support/Helper/GFHelpers/GFHelpers.php
+++ b/tests/_support/Helper/GFHelpers/GFHelpers.php
@@ -16,7 +16,7 @@ abstract class GFHelpers {
 	/**
 	 * Provides access to dummy functions.
 	 *
-	 * @var Dummy
+	 * @var \Dummy
 	 */
 	public $dummy;
 
@@ -26,13 +26,13 @@ abstract class GFHelpers {
 	 * @var array
 	 */
 	public $keys;
+
 	/**
 	 * The generated list of values.
 	 *
 	 * @var array
 	 */
 	public $values;
-
 
 	/**
 	 * Constructor
@@ -49,8 +49,6 @@ abstract class GFHelpers {
 
 	/**
 	 * Flattens key => value pairs to grab all the keys.
-	 *
-	 * @param array $keys
 	 */
 	public function get_keys( array $keys ) {
 		$return_values = [];
@@ -68,7 +66,6 @@ abstract class GFHelpers {
 	/**
 	 * Gets the key => value pair for the given key name.
 	 *
-	 * @param string $key
 	 * @param [type] $value
 	 */
 	public function get( string $key, $value = null ) {
@@ -77,8 +74,6 @@ abstract class GFHelpers {
 
 	/**
 	 * Gets all key => value pairs for the defined keys.
-	 *
-	 * @param array $keys
 	 */
 	public function getAll( array $keys ) {
 		$return_values = [];

--- a/tests/_support/Helper/GFHelpers/PropertyHelper.php
+++ b/tests/_support/Helper/GFHelpers/PropertyHelper.php
@@ -3,7 +3,6 @@
 namespace Helper\GFHelpers;
 
 class PropertyHelper extends GFHelpers {
-
 	public function addIconUrl( $value = null ) {
 		return ! empty( $value ) ? $value : 'someurl.test';
 	}
@@ -92,7 +91,7 @@ class PropertyHelper extends GFHelpers {
 		return ! empty( $value ) ? $value : null;
 	}
 
-	public function chainedSelectsHideInactive( $value = null ) : bool {
+	public function chainedSelectsHideInactive( $value = null ): bool {
 		return ! empty( $value );
 	}
 
@@ -100,7 +99,7 @@ class PropertyHelper extends GFHelpers {
 		return ! empty( $value ) ? $value : null;
 	}
 
-	public function copyValuesOptionDefault( $value = null ) : bool {
+	public function copyValuesOptionDefault( $value = null ): bool {
 		return ! empty( $value );
 	}
 
@@ -144,91 +143,91 @@ class PropertyHelper extends GFHelpers {
 		return ! empty( $value ) ? $value : $this->dummy->text();
 	}
 
-	public function descriptionPlacement( $value = null ) : string {
+	public function descriptionPlacement( $value = null ): string {
 		return null !== $value ? $value : 'above';
 	}
 
-	public function disableQuantity( $value = null ) : bool {
+	public function disableQuantity( $value = null ): bool {
 		return null !== $value ? $value : false;
 	}
 
-	public function disableMargins( $value = null ) : bool {
+	public function disableMargins( $value = null ): bool {
 		return null !== $value ? $value : $this->dummy->yesno();
 	}
 
-	public function displayAlt( $value = null ) : bool {
+	public function displayAlt( $value = null ): bool {
 		return null !== $value ? ! empty( $value ) : $this->dummy->yesno();
 	}
 
-
-	public function displayAllCategories( $value = null ) : bool {
+	public function displayAllCategories( $value = null ): bool {
 		return ! empty( $value );
 	}
 
-	public function displayCaption( $value = null ) : bool {
+	public function displayCaption( $value = null ): bool {
 		return null !== $value ? ! empty( $value ) : $this->dummy->yesno();
 	}
 
-	public function displayDescription( $value = null ) : bool {
+	public function displayDescription( $value = null ): bool {
 		return null !== $value ? ! empty( $value ) : $this->dummy->yesno();
 	}
 
-	public function displayOnly( $value = null ) : bool {
+	public function displayOnly( $value = null ): bool {
 		return ! empty( $value );
 	}
 
-	public function displayTitle( $value = null ) : bool {
+	public function displayTitle( $value = null ): bool {
 		return null !== $value ? ! empty( $value ) : $this->dummy->yesno();
 	}
 
-	public function emailConfirmEnabled( $value = null ) : bool {
+	public function emailConfirmEnabled( $value = null ): bool {
 		return ! empty( $value );
 	}
 
-	public function enableAutocomplete( $value = null ) : bool {
+	public function enableAutocomplete( $value = null ): bool {
 		return null !== $value ? ! empty( $value ) : (bool) $this->dummy->yesno();
 	}
 
-	public function enableCalculation( $value = null ) : bool {
+	public function enableCalculation( $value = null ): bool {
 		return ! empty( $value );
 	}
 
-	public function enableChoiceValue( $value = null ) : bool {
+	public function enableChoiceValue( $value = null ): bool {
 		return null !== $value ? ! empty( $value ) : (bool) $this->dummy->yesno();
 	}
 
-	public function enableCopyValuesOption( $value = null ) : bool {
+	public function enableCopyValuesOption( $value = null ): bool {
 		return null !== $value ? ! empty( $value ) : $this->dummy->yesno();
 	}
 
-	public function enableEnhancedUI( $value = null ) : bool {
+	public function enableEnhancedUI( $value = null ): bool {
 		return null !== $value ? ! empty( $value ) : $this->dummy->yesno();
 	}
 
-	public function enableOtherChoice( $value = null ) : bool {
+	public function enableOtherChoice( $value = null ): bool {
 		return null !== $value ? ! empty( $value ) : $this->dummy->yesno();
 	}
 
-	public function enablePasswordInput( $value = null ) : bool {
+	public function enablePasswordInput( $value = null ): bool {
 		return null !== $value ? ! empty( $value ) : $this->dummy->yesno();
 	}
 
-	public function enablePrice( $value = null ) : bool {
+	public function enablePrice( $value = null ): bool {
 		return null !== $value ? ! empty( $value ) : true;
 	}
 
-	public function gquizEnableRandomizeQuizChoices( bool $value = null ) : bool {
+	public function gquizEnableRandomizeQuizChoices( ?bool $value = null ): bool {
 		return null !== $value ? ! empty( $value ) : $this->dummy->yesno();
 	}
 
-	public function enableSelectAll( $value = null ) : bool {
+	public function enableSelectAll( $value = null ): bool {
 		return null !== $value ? ! empty( $value ) : $this->dummy->yesno();
 	}
-	public function enableColumns( $value = null ) : bool {
+
+	public function enableColumns( $value = null ): bool {
 		return null !== $value ? ! empty( $value ) : false;
 	}
 
-	public function gquizWeightedScoreEnabled( bool $value = null ) : ?bool {
+	public function gquizWeightedScoreEnabled( ?bool $value = null ): ?bool {
 		return null !== $value ? $value : $this->dummy->yesno();
 	}
 
@@ -256,14 +255,14 @@ class PropertyHelper extends GFHelpers {
 		return ! empty( $value ) ? $value : null;
 	}
 
-	public function gquizAnswerExplanation( string $value = null ) : ?string {
+	public function gquizAnswerExplanation( ?string $value = null ): ?string {
 		return ! empty( $value ) ? $value : $this->dummy->sentence( 1, 3 );
 	}
 
-	public function gquizIsCorrect( bool $value = null ) : ?bool {
+	public function gquizIsCorrect( ?bool $value = null ): ?bool {
 		return null !== $value ? ! empty( $value ) : (bool) $this->dummy->yesno();  }
 
-	public function hasInputMask( bool $value = null ) : ?bool {
+	public function hasInputMask( ?bool $value = null ): ?bool {
 		return null !== $value ? $value : $this->dummy->yesno();
 	}
 
@@ -305,11 +304,12 @@ class PropertyHelper extends GFHelpers {
 	public function maxLength( $value = null ) {
 		return ! empty( $value ) ? $value : ( rand( 100, 550 ) ?: null );
 	}
+
 	public function maxRows( $value = null ) {
 		return ! empty( $value ) ? $value : ( rand( 3, 10 ) ?: null );
 	}
 
-	public function multipleFiles( $value = null ) : bool {
+	public function multipleFiles( $value = null ): bool {
 		return ! empty( $value );
 	}
 
@@ -325,7 +325,7 @@ class PropertyHelper extends GFHelpers {
 		return ! empty( $value ) ? $value : 'advanced';
 	}
 
-	public function noDuplicates( bool $value = null ) : bool {
+	public function noDuplicates( ?bool $value = null ): bool {
 		return null !== $value ? $value : false;
 	}
 
@@ -345,10 +345,10 @@ class PropertyHelper extends GFHelpers {
 		return ! empty( $value ) ? $value : $this->dummy->number( 1, 3 );
 	}
 
-	public function personalDataErase( $value = null ) : bool {
+	public function personalDataErase( $value = null ): bool {
 		return null !== $value ? ! empty( $value ) : (bool) $this->dummy->yesno();  }
 
-	public function personalDataExport( $value = null ) : bool {
+	public function personalDataExport( $value = null ): bool {
 		return null !== $value ? ! empty( $value ) : (bool) $this->dummy->yesno();
 	}
 
@@ -376,7 +376,7 @@ class PropertyHelper extends GFHelpers {
 		return ! empty( $value ) ? $value : '';
 	}
 
-	public function gquizFieldType( string $value = null ) : string {
+	public function gquizFieldType( ?string $value = null ): string {
 		return ! empty( $value ) ? $value : 'CHECKBOX';
 	}
 
@@ -388,7 +388,7 @@ class PropertyHelper extends GFHelpers {
 		return ! empty( $value ) ? $value : null;
 	}
 
-	public function gquizShowAnswerExplanation( bool $value = null ): ?bool {
+	public function gquizShowAnswerExplanation( ?bool $value = null ): ?bool {
 		return null !== $value ? ! empty( $value ) : (bool) $this->dummy->yesno();
 	}
 
@@ -404,7 +404,7 @@ class PropertyHelper extends GFHelpers {
 		return $this->size( $value );
 	}
 
-	public function size( $value = null ) : string {
+	public function size( $value = null ): string {
 		return $value ?: 'medium';
 	}
 
@@ -461,5 +461,4 @@ class PropertyHelper extends GFHelpers {
 	public function gquizWeight( $value = null ) {
 		return ! empty( $value ) ? $value : $this->dummy->number( 0, 5 );
 	}
-
 }

--- a/tests/_support/Helper/GFHelpers/inc/Dummy.php
+++ b/tests/_support/Helper/GFHelpers/inc/Dummy.php
@@ -75,7 +75,6 @@ class Dummy {
 		return( rand( 1943, 2025 ) . '-0' . rand( 1, 9 ) . '-' . rand( 11, 30 ) );
 	}
 
-
 	public function hm( $s = false ) {
 		$t = rand( 1, 12 ) . ':' . rand( 10, 59 );
 

--- a/tests/_support/Helper/Unit.php
+++ b/tests/_support/Helper/Unit.php
@@ -5,6 +5,4 @@ namespace Helper;
 // all public methods declared in helper class will be available in $I
 
 class Unit extends \Codeception\Module {
-
-
 }

--- a/tests/_support/Helper/Wpunit.php
+++ b/tests/_support/Helper/Wpunit.php
@@ -14,15 +14,13 @@ use Helper\GFHelpers\PropertyHelper;
  * All public methods declared in helper class will be available in $I
  */
 class Wpunit extends \Codeception\Module {
-
 	/**
 	 * Generates the property helper for the field.
 	 *
 	 * @param string $type .
 	 * @param array  $args .
-	 * @return PropertyHelper
 	 */
-	public function getPropertyHelper( string $type, array $args = [] ) : PropertyHelper {
+	public function getPropertyHelper( string $type, array $args = [] ): PropertyHelper {
 		$interface_defaults = $this->getDefaultArgs();
 		$field_defaults     = call_user_func( [ $this, "get{$type}Args" ] );
 
@@ -34,7 +32,7 @@ class Wpunit extends \Codeception\Module {
 	/**
 	 * Gets the default args used by all fields.
 	 */
-	public function getDefaultArgs() : array {
+	public function getDefaultArgs(): array {
 		return [
 			'displayOnly',
 			[ 'conditionalLogic' => null ],
@@ -53,7 +51,7 @@ class Wpunit extends \Codeception\Module {
 	/**
 	 * Get the default args for an address field.
 	 */
-	public function getAddressFieldArgs() : array {
+	public function getAddressFieldArgs(): array {
 		return [
 			'addressType',
 			'adminLabel',
@@ -87,7 +85,7 @@ class Wpunit extends \Codeception\Module {
 	/**
 	 * Get the default args for a Captcha field.
 	 */
-	public function getCaptchaFieldArgs() : array {
+	public function getCaptchaFieldArgs(): array {
 		return [
 			'captchaBadgePosition',
 			'captchaLanguage',
@@ -108,7 +106,7 @@ class Wpunit extends \Codeception\Module {
 	/**
 	 * Get the default args for a ChainedSelect field.
 	 */
-	public function getChainedSelectFieldArgs() : array {
+	public function getChainedSelectFieldArgs(): array {
 		return [
 			'adminLabel',
 			'allowsPrepopulate',
@@ -222,7 +220,7 @@ class Wpunit extends \Codeception\Module {
 	/**
 	 * Get the default args for a Checkbox field.
 	 */
-	public function getCheckboxFieldArgs() : array {
+	public function getCheckboxFieldArgs(): array {
 		return [
 			'adminLabel',
 			'allowsPrepopulate',
@@ -268,7 +266,7 @@ class Wpunit extends \Codeception\Module {
 	/**
 	 * Get the default args for a consent field.
 	 */
-	public function getConsentFieldArgs() : array {
+	public function getConsentFieldArgs(): array {
 		return [
 			'adminLabel',
 			'checkboxLabel',
@@ -313,7 +311,7 @@ class Wpunit extends \Codeception\Module {
 	/**
 	 * Get the default args for a consent field.
 	 */
-	public function getDateFieldArgs() : array {
+	public function getDateFieldArgs(): array {
 		return [
 			'adminLabel',
 			'allowsPrepopulate',
@@ -346,7 +344,7 @@ class Wpunit extends \Codeception\Module {
 	/**
 	 * Get the default args for an email field.
 	 */
-	public function getEmailFieldArgs() : array {
+	public function getEmailFieldArgs(): array {
 		return [
 			'adminLabel',
 			'allowsPrepopulate',
@@ -393,7 +391,7 @@ class Wpunit extends \Codeception\Module {
 	/**
 	 * Get the default args for an email field.
 	 */
-	public function getFileUploadFieldArgs() : array {
+	public function getFileUploadFieldArgs(): array {
 		return [
 			'adminLabel',
 			'allowedExtensions',
@@ -414,7 +412,7 @@ class Wpunit extends \Codeception\Module {
 	/**
 	 * Get the default args for a hidden field.
 	 */
-	public function getHiddenFieldArgs() : array {
+	public function getHiddenFieldArgs(): array {
 		return [
 			[ 'cssClass' => null ],
 			[ 'adminLabel' => null ],
@@ -431,7 +429,7 @@ class Wpunit extends \Codeception\Module {
 	/**
 	 * Get args for HTML field.
 	 */
-	public function getHtmlFieldArgs() : array {
+	public function getHtmlFieldArgs(): array {
 		return [
 			'adminLabel',
 			'content',
@@ -442,10 +440,11 @@ class Wpunit extends \Codeception\Module {
 			[ 'type' => 'html' ],
 		];
 	}
+
 	/**
 	 * Get the default args for a list field.
 	 */
-	public function getListFieldArgs() : array {
+	public function getListFieldArgs(): array {
 		return [
 			'addIconUrl',
 			'adminLabel',
@@ -484,7 +483,7 @@ class Wpunit extends \Codeception\Module {
 	/**
 	 * Get the default args for a MultiSelect field.
 	 */
-	public function getMultiSelectFieldArgs() : array {
+	public function getMultiSelectFieldArgs(): array {
 		return [
 			'adminLabel',
 			'allowsPrepopulate',
@@ -525,7 +524,7 @@ class Wpunit extends \Codeception\Module {
 	/**
 	 * Get the default args for a name field.
 	 */
-	public function getNameFieldArgs() : array {
+	public function getNameFieldArgs(): array {
 		return [
 			'adminLabel',
 			'allowsPrepopulate',
@@ -615,7 +614,7 @@ class Wpunit extends \Codeception\Module {
 	/**
 	 * Get the default args for a number field.
 	 */
-	public function getNumberFieldArgs() : array {
+	public function getNumberFieldArgs(): array {
 		return [
 			'adminLabel',
 			'allowsPrepopulate',
@@ -645,7 +644,7 @@ class Wpunit extends \Codeception\Module {
 	/**
 	 * Get the default args for an Option field.
 	 */
-	public function getOptionFieldArgs() : array {
+	public function getOptionFieldArgs(): array {
 		return [
 			'adminLabel',
 			'allowsPrepopulate',
@@ -694,7 +693,7 @@ class Wpunit extends \Codeception\Module {
 	/**
 	 * Get args for page field.
 	 */
-	public function getPageFieldArgs() : array {
+	public function getPageFieldArgs(): array {
 		return [
 			'adminLabel',
 			[
@@ -722,7 +721,7 @@ class Wpunit extends \Codeception\Module {
 	/**
 	 * Get the default args for a Phone field.
 	 */
-	public function getPhoneFieldArgs() : array {
+	public function getPhoneFieldArgs(): array {
 		return [
 			'adminLabel',
 			'allowsPrepopulate',
@@ -748,7 +747,7 @@ class Wpunit extends \Codeception\Module {
 	/**
 	 * Get the default args for a PostContent field.
 	 */
-	public function getPostContentFieldArgs() : array {
+	public function getPostContentFieldArgs(): array {
 		return [
 			'adminLabel',
 			'allowsPrepopulate',
@@ -770,7 +769,7 @@ class Wpunit extends \Codeception\Module {
 	/**
 	 * Get the default args for a PostContent field.
 	 */
-	public function getPostCategoryFieldArgs() : array {
+	public function getPostCategoryFieldArgs(): array {
 		return [
 			'adminLabel',
 			'allowsPrepopulate',
@@ -793,7 +792,7 @@ class Wpunit extends \Codeception\Module {
 	/**
 	 * Get the default args for a PostExcerpt field.
 	 */
-	public function getPostExcerptFieldArgs() : array {
+	public function getPostExcerptFieldArgs(): array {
 		return [
 			'adminLabel',
 			'allowsPrepopulate',
@@ -812,11 +811,10 @@ class Wpunit extends \Codeception\Module {
 		];
 	}
 
-
 	/**
 	 * Get the default args for an email field.
 	 */
-	public function getPostImageFieldArgs() : array {
+	public function getPostImageFieldArgs(): array {
 		return [
 			'adminLabel',
 			'allowedExtensions',
@@ -839,7 +837,7 @@ class Wpunit extends \Codeception\Module {
 	/**
 	 * Get the default args for a PostContent field.
 	 */
-	public function getPostTagsFieldArgs() : array {
+	public function getPostTagsFieldArgs(): array {
 		return [
 			'adminLabel',
 			'allowsPrepopulate',
@@ -860,7 +858,7 @@ class Wpunit extends \Codeception\Module {
 	/**
 	 * Get the default args for a PostTitle field.
 	 */
-	public function getPostTitleFieldArgs() : array {
+	public function getPostTitleFieldArgs(): array {
 		return [
 			'adminLabel',
 			'allowsPrepopulate',
@@ -882,7 +880,7 @@ class Wpunit extends \Codeception\Module {
 	/**
 	 * Get the default args for a Product field
 	 */
-	public function getProductFieldArgs() : array {
+	public function getProductFieldArgs(): array {
 		return [
 			'adminLabel',
 			'allowsPrepopulate',
@@ -906,11 +904,10 @@ class Wpunit extends \Codeception\Module {
 		];
 	}
 
-
 	/**
 	 * Get the default args for a quantity field.
 	 */
-	public function getQuantityFieldArgs() : array {
+	public function getQuantityFieldArgs(): array {
 		return [
 			'adminLabel',
 			'allowsPrepopulate',
@@ -933,7 +930,7 @@ class Wpunit extends \Codeception\Module {
 	/**
 	 * Get the default args for a Quiz field
 	 */
-	public function getQuizFieldArgs() : array {
+	public function getQuizFieldArgs(): array {
 		return [
 			'autocompleteAttribute',
 			'adminLabel',
@@ -994,7 +991,7 @@ class Wpunit extends \Codeception\Module {
 	/**
 	 * Get the default args for a radio field.
 	 */
-	public function getRadioFieldArgs() : array {
+	public function getRadioFieldArgs(): array {
 		return [
 			'adminLabel',
 			'allowsPrepopulate',
@@ -1034,7 +1031,7 @@ class Wpunit extends \Codeception\Module {
 	/**
 	 * Get args for section field.
 	 */
-	public function getSectionFieldArgs() : array {
+	public function getSectionFieldArgs(): array {
 		return [
 			'adminLabel',
 			[ 'displayOnly' => true ],
@@ -1047,7 +1044,7 @@ class Wpunit extends \Codeception\Module {
 	/**
 	 * Get the default args for a select field.
 	 */
-	public function getSelectFieldArgs() : array {
+	public function getSelectFieldArgs(): array {
 		return [
 			'adminLabel',
 			'allowsPrepopulate',
@@ -1091,7 +1088,7 @@ class Wpunit extends \Codeception\Module {
 	/**
 	 * Get the default args for a shipping field.
 	 */
-	public function getShippingFieldArgs() : array {
+	public function getShippingFieldArgs(): array {
 		return [
 			'adminLabel',
 			'allowsPrepopulate',
@@ -1108,11 +1105,10 @@ class Wpunit extends \Codeception\Module {
 		];
 	}
 
-
 	/**
 	 * Get the default args for a signature field.
 	 */
-	public function getSignatureFieldArgs() : array {
+	public function getSignatureFieldArgs(): array {
 		return [
 			'adminLabel',
 			'backgroundColor',
@@ -1138,7 +1134,7 @@ class Wpunit extends \Codeception\Module {
 	/**
 	 * Get the default args for a text field.
 	 */
-	public function getTextFieldArgs() : array {
+	public function getTextFieldArgs(): array {
 		return [
 			'adminLabel',
 			'allowsPrepopulate',
@@ -1165,7 +1161,7 @@ class Wpunit extends \Codeception\Module {
 	/**
 	 * Get the default args for a textarea field.
 	 */
-	public function getTextAreaFieldArgs() : array {
+	public function getTextAreaFieldArgs(): array {
 		return [
 			'adminLabel',
 			'allowsPrepopulate',
@@ -1189,7 +1185,7 @@ class Wpunit extends \Codeception\Module {
 	/**
 	 * Get the default args for a time field.
 	 */
-	public function getTimeFieldArgs() : array {
+	public function getTimeFieldArgs(): array {
 		return [
 			'adminLabel',
 			'allowsPrepopulate',
@@ -1232,7 +1228,7 @@ class Wpunit extends \Codeception\Module {
 	/**
 	 * Get the default args for a total field.
 	 */
-	public function getTotalFieldArgs() : array {
+	public function getTotalFieldArgs(): array {
 		return [
 			'adminLabel',
 			'description',
@@ -1243,11 +1239,10 @@ class Wpunit extends \Codeception\Module {
 		];
 	}
 
-
 	/**
 	 * Get default args for website field.
 	 */
-	public function getWebsiteFieldArgs() : array {
+	public function getWebsiteFieldArgs(): array {
 		return [
 			'adminLabel',
 			'defaultValue',
@@ -1270,7 +1265,7 @@ class Wpunit extends \Codeception\Module {
 	 *
 	 * @param array $args .
 	 */
-	public function getFormDefaultArgs( $args = [] ) : array {
+	public function getFormDefaultArgs( $args = [] ): array {
 		return array_merge(
 			[
 				'button'                     => [
@@ -1479,7 +1474,6 @@ class Wpunit extends \Codeception\Module {
 		);
 	}
 
-
 	/**
 	 * Converts a string value to its Enum equivalent
 	 *
@@ -1502,7 +1496,7 @@ class Wpunit extends \Codeception\Module {
 	 * @param array $default .
 	 * @param array $custom .
 	 */
-	public function merge_default_args( array $default, array $custom = [] ) : array {
+	public function merge_default_args( array $default, array $custom = [] ): array {
 		array_walk(
 			$default,
 			static function ( &$value ) use ( $custom ) {

--- a/tests/_support/TestCase/FormFieldTestCase.php
+++ b/tests/_support/TestCase/FormFieldTestCase.php
@@ -10,8 +10,8 @@
 
 namespace Tests\WPGraphQL\GF\TestCase;
 
-use GFFormsModel;
 use GFAPI;
+use GFFormsModel;
 use GF_Field;
 use Helper\GFHelpers\ExpectedFormFields;
 use WPGraphQL\GF\Registry\FieldChoiceRegistry;
@@ -59,6 +59,7 @@ class FormFieldTestCase extends GFGraphQLTestCase {
 	public function setUp(): void {
 		// Before...
 		$this->is_draft = false;
+
 		parent::setUp();
 
 		wp_set_current_user( $this->admin->ID );
@@ -124,15 +125,13 @@ class FormFieldTestCase extends GFGraphQLTestCase {
 	 * @uses $this->fields
 	 * @uses $this->form_args
 	 */
-	public function createTestForm() : int {
-		$form_id = $this->factory->form->create(
+	public function createTestForm(): int {
+		return $this->factory->form->create(
 			array_merge(
 				[ 'fields' => $this->fields ],
 				$this->form_args,
 			)
 		);
-
-		return $form_id;
 	}
 
 	/**
@@ -140,15 +139,11 @@ class FormFieldTestCase extends GFGraphQLTestCase {
 	 *
 	 * @uses $this->form
 	 * @uses $this->value
-	 *
-	 * @return integer
 	 */
-	public function createTestEntry() : int {
-		$entry_id = $this->factory->entry->create(
+	public function createTestEntry(): int {
+		return $this->factory->entry->create(
 			[ 'form_id' => $this->form_id ] + $this->value
 		);
-
-		return $entry_id;
 	}
 
 	/**
@@ -157,13 +152,11 @@ class FormFieldTestCase extends GFGraphQLTestCase {
 	 * @uses $this->get_draft_field_values()
 	 * @uses $this->form_id
 	 * @uses $this->value
-	 *
-	 * @return string
 	 */
-	public function createDraftEntry() : string {
+	public function createDraftEntry(): string {
 		$draft_entry_field_values = $this->get_draft_field_values();
 
-		$draft_token = $this->factory->draft_entry->create(
+		return $this->factory->draft_entry->create(
 			[
 				'form_id'     => $this->form_id,
 				'entry'       => $this->value + [
@@ -173,8 +166,6 @@ class FormFieldTestCase extends GFGraphQLTestCase {
 				'fieldValues' => $draft_entry_field_values,
 			]
 		);
-
-		return $draft_token;
 	}
 
 	/**
@@ -190,7 +181,7 @@ class FormFieldTestCase extends GFGraphQLTestCase {
 		);
 	}
 
-	public function mutation_value_field_id() : int {
+	public function mutation_value_field_id(): int {
 		return $this->fields[0]->id;
 	}
 
@@ -246,6 +237,7 @@ class FormFieldTestCase extends GFGraphQLTestCase {
 	public function updated_field_value_input() {
 		return $this->updated_field_value;
 	}
+
 	/**
 	 * The graphql field value input.
 	 */
@@ -256,7 +248,7 @@ class FormFieldTestCase extends GFGraphQLTestCase {
 	/**
 	 * The entire GraphQL query with the form field values added.
 	 */
-	protected function entry_query() : string {
+	protected function entry_query(): string {
 		return "
 			query getFieldValue(\$id: ID!, \$idType: EntryIdTypeEnum) {
 				gfEntry(id: \$id, idType: \$idType ) {
@@ -295,7 +287,7 @@ class FormFieldTestCase extends GFGraphQLTestCase {
 		$this->assertArrayNotHasKey( 'errors', $response, 'field has errors' );
 
 		// Assert that their are no debug messages.
-		$this->assertEmpty( $response['extensions']['debug'], print_r($response['extensions']['debug'], true ) );
+		$this->assertEmpty( $response['extensions']['debug'], print_r( $response['extensions']['debug'], true ) );
 
 		$expected = $this->expected_field_response( $form );
 
@@ -320,7 +312,7 @@ class FormFieldTestCase extends GFGraphQLTestCase {
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
-	protected function runTestSubmitDraft() : void {
+	protected function runTestSubmitDraft(): void {
 		$this->is_draft = true;
 		wp_set_current_user( $this->admin->ID );
 
@@ -347,7 +339,7 @@ class FormFieldTestCase extends GFGraphQLTestCase {
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
-	protected function runtestSubmitForm() : void {
+	protected function runtestSubmitForm(): void {
 		$this->is_draft = false;
 		$form           = $this->factory->form->get_object_by_id( $this->form_id );
 		wp_set_current_user( $this->admin->ID );
@@ -364,7 +356,7 @@ class FormFieldTestCase extends GFGraphQLTestCase {
 		$response = $this->graphql( compact( 'query', 'variables' ) );
 
 		$expected = $this->expected_mutation_response( 'submitGfForm', $this->field_value );
-	
+
 		$this->assertQuerySuccessful( $response, $expected );
 		$this->assertEquals( $response['data']['submitGfForm']['errors'], null );
 
@@ -382,7 +374,7 @@ class FormFieldTestCase extends GFGraphQLTestCase {
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
-	protected function runtestUpdateEntry() : void {
+	protected function runtestUpdateEntry(): void {
 		$this->is_draft = false;
 		wp_set_current_user( $this->admin->ID );
 
@@ -409,7 +401,7 @@ class FormFieldTestCase extends GFGraphQLTestCase {
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	protected function runTestUpdateDraft() : void {
+	protected function runTestUpdateDraft(): void {
 		$this->is_draft = true;
 		wp_set_current_user( $this->admin->ID );
 

--- a/tests/_support/TestCase/FormFieldTestCaseInterface.php
+++ b/tests/_support/TestCase/FormFieldTestCaseInterface.php
@@ -16,7 +16,7 @@ interface FormFieldTestCaseInterface {
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array;
+	public function generate_fields(): array;
 
 	/**
 	 * The value as expected in GraphQL.
@@ -45,47 +45,44 @@ interface FormFieldTestCaseInterface {
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string;
+	public function field_query(): string;
 
 	/**
 	 * SubmitForm mutation string.
 	 */
-	public function submit_form_mutation() : string;
+	public function submit_form_mutation(): string;
 
 	/**
 	 * Returns the UpdateEntry mutation string.
 	 */
-	public function update_entry_mutation() : string;
+	public function update_entry_mutation(): string;
 
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
 	 */
-	public function update_draft_entry_mutation() : string;
+	public function update_draft_entry_mutation(): string;
 
 	/**
 	 * The expected WPGraphQL field response.
 	 *
-	 * @param array $form the current form instance.
+	 * @param array<string,mixed> $form The current form array.
 	 */
-	public function expected_field_response( array $form ) : array;
+	public function expected_field_response( array $form ): array;
 
 	/**
 	 * The expected WPGraphQL mutation response.
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value) : array;
+	public function expected_mutation_response( string $mutationName, $value ): array;
 
 	/**
 	 * Checks if values submitted by GraphQL are the same as whats stored on the server.
 	 *
-	 * @param array $actual_entry .
-	 * @param array $form .
+	 * @param array               $actual_entry .
+	 * @param array<string,mixed> $form The form array.
 	 */
-	public function check_saved_values( $actual_entry, $form ) : void;
+	public function check_saved_values( $actual_entry, $form ): void;
 }

--- a/tests/_support/TestCase/GFGraphQLTestCase.php
+++ b/tests/_support/TestCase/GFGraphQLTestCase.php
@@ -11,7 +11,6 @@
 namespace Tests\WPGraphQL\GF\TestCase;
 
 use Helper\GFHelpers\GFHelpers;
-use RuntimeException;
 use WPGraphQL\GF\Type\Enum;
 
 /**
@@ -40,7 +39,7 @@ class GFGraphQLTestCase extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 	/**
 	 * Creates users and loads factories.
 	 */
-	public function setUp() : void {
+	public function setUp(): void {
 		parent::setUp();
 
 		// Load factories.
@@ -84,7 +83,6 @@ class GFGraphQLTestCase extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 	 * Programmatically generate an expectedField array for assertions.
 	 *
 	 * @param array $value_array .
-	 * @return array
 	 */
 	protected function get_expected_fields( $value_array ): array {
 		$expected = [];
@@ -96,23 +94,23 @@ class GFGraphQLTestCase extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	public function get_expected_conditional_logic_fields( $conditional_logic ) {
 		if ( empty( $conditional_logic ) ) {
-			return $this->expectedField( 'conditionalLogic', static::IS_NULL );
+			return $this->expectedField( 'conditionalLogic', self::IS_NULL );
 		}
 
 		return $this->expectedObject(
 			'conditionalLogic',
 			[
-				$this->expectedField( 'actionType', ! empty( $conditional_logic['actionType'] ) ? GFHelpers::get_enum_for_value( Enum\ConditionalLogicActionTypeEnum::$type, $conditional_logic['actionType'] ) : static::IS_NULL ),
+				$this->expectedField( 'actionType', ! empty( $conditional_logic['actionType'] ) ? GFHelpers::get_enum_for_value( Enum\ConditionalLogicActionTypeEnum::$type, $conditional_logic['actionType'] ) : self::IS_NULL ),
 				$this->expectedField(
 					'logicType',
-					! empty( $conditional_logic['actionType'] ) ? GFHelpers::get_enum_for_value( Enum\ConditionalLogicLogicTypeEnum::$type, $conditional_logic['logicType'] ) : static::IS_NULL
+					! empty( $conditional_logic['actionType'] ) ? GFHelpers::get_enum_for_value( Enum\ConditionalLogicLogicTypeEnum::$type, $conditional_logic['logicType'] ) : self::IS_NULL
 				),
 				$this->expectedNode(
 					'rules',
 					[
-						$this->expectedField( 'fieldId', ! empty( $conditional_logic['rules'][0]['fieldId'] ) ? (float) $conditional_logic['rules'][0]['fieldId'] : static::IS_NULL ),
-						$this->expectedField( 'operator', ! empty( $conditional_logic['rules'][0]['operator'] ) ? GFHelpers::get_enum_for_value( Enum\FormRuleOperatorEnum::$type, $conditional_logic['rules'][0]['operator'] ) : static::IS_NULL ),
-						$this->expectedField( 'value', ! empty( $conditional_logic['rules'][0]['value'] ) ? $conditional_logic['rules'][0]['value'] : static::IS_NULL ),
+						$this->expectedField( 'fieldId', ! empty( $conditional_logic['rules'][0]['fieldId'] ) ? (float) $conditional_logic['rules'][0]['fieldId'] : self::IS_NULL ),
+						$this->expectedField( 'operator', ! empty( $conditional_logic['rules'][0]['operator'] ) ? GFHelpers::get_enum_for_value( Enum\FormRuleOperatorEnum::$type, $conditional_logic['rules'][0]['operator'] ) : self::IS_NULL ),
+						$this->expectedField( 'value', ! empty( $conditional_logic['rules'][0]['value'] ) ? $conditional_logic['rules'][0]['value'] : self::IS_NULL ),
 					],
 					0
 				),

--- a/tests/_support/UnitTester.php
+++ b/tests/_support/UnitTester.php
@@ -3,6 +3,7 @@
 
 /**
  * Inherited Methods
+ *
  * @method void wantToTest($text)
  * @method void wantTo($text)
  * @method void execute($callable)
@@ -14,13 +15,12 @@
  * @method void comment($description)
  * @method void pause()
  *
- * @SuppressWarnings(PHPMD)
-*/
-class UnitTester extends \Codeception\Actor
-{
-    use _generated\UnitTesterActions;
+ * @SuppressWarnings(\PHPMD)
+ */
+class UnitTester extends \Codeception\Actor {
+	use _generated\UnitTesterActions;
 
-    /**
-     * Define custom actions here
-     */
+	/**
+	 * Define custom actions here
+	 */
 }

--- a/tests/_support/WpunitTester.php
+++ b/tests/_support/WpunitTester.php
@@ -3,6 +3,7 @@
 
 /**
  * Inherited Methods
+ *
  * @method void wantToTest($text)
  * @method void wantTo($text)
  * @method void execute($callable)
@@ -14,13 +15,12 @@
  * @method void comment($description)
  * @method void pause()
  *
- * @SuppressWarnings(PHPMD)
-*/
-class WpunitTester extends \Codeception\Actor
-{
-    use _generated\WpunitTesterActions;
+ * @SuppressWarnings(\PHPMD)
+ */
+class WpunitTester extends \Codeception\Actor {
+	use _generated\WpunitTesterActions;
 
-    /**
-     * Define custom actions here
-     */
+	/**
+	 * Define custom actions here
+	 */
 }

--- a/tests/acceptance/ActivationCest.php
+++ b/tests/acceptance/ActivationCest.php
@@ -1,7 +1,6 @@
 <?php
 
 class ActivationCest {
-
 	// tests
 	public function testActivation( AcceptanceTester $I ) {
 		$pluginSlug = 'wp-graphql-gravity-forms';

--- a/tests/unit/UtilsUtilsTest.php
+++ b/tests/unit/UtilsUtilsTest.php
@@ -14,7 +14,7 @@ class UtilsUtilsTest extends \Codeception\Test\Unit {
 		/**
 		 * Tests that deprecationReason is added to the property definition.
 		 */
-	public function testDeprecateProperty() : void {
+	public function testDeprecateProperty(): void {
 		$property = [
 			'propertyName' => [
 				'type'        => 'String',

--- a/tests/wpunit/AddressFieldTest.php
+++ b/tests/wpunit/AddressFieldTest.php
@@ -20,28 +20,32 @@ class AddressFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -55,7 +59,7 @@ class AddressFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [ $this->factory->field->create( $this->property_helper->values ) ];
 	}
 
@@ -72,7 +76,6 @@ class AddressFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 			'country' => 'US',
 		];
 	}
-
 
 	/**
 	 * Sets the value as expected by Gravity Forms.
@@ -102,14 +105,10 @@ class AddressFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 		];
 	}
 
-
-
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on AddressField {
 				addressType
@@ -172,10 +171,8 @@ class AddressFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 
 	/**
 	 * SubmitForm mutation string.
-	 *
-	 * @return string
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ($formId: ID!, $fieldId: Int!, $value: AddressFieldInput!, $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: {id: $fieldId, addressValues: $value}}) {
@@ -212,8 +209,6 @@ class AddressFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 
 	/**
 	 * Returns the UpdateEntry mutation string.
-	 *
-	 * @return string
 	 */
 	public function update_entry_mutation(): string {
 		return '
@@ -246,8 +241,6 @@ class AddressFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
-	 *
-	 * @return string
 	 */
 	public function update_draft_entry_mutation(): string {
 		return '
@@ -277,13 +270,11 @@ class AddressFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 			}
 		';
 	}
+
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
-	 * @return array
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
 		$expected[] = $this->expected_field_value( 'addressValues', $this->field_value );
 
@@ -311,9 +302,8 @@ class AddressFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,
@@ -343,8 +333,8 @@ class AddressFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 	/**
 	 * Checks if values submitted by GraphQL are the same as whats stored on the server.
 	 *
-	 * @param array $actual_entry .
-	 * @param array $form .
+	 * @param array               $actual_entry .
+	 * @param array<string,mixed> $form The form array.
 	 */
 	public function check_saved_values( $actual_entry, $form ): void {
 		$this->assertEquals( $this->field_value['street'], $actual_entry[ $form['fields'][0]['inputs'][0]['id'] ], 'Submit mutation entry value 1 not equal' );

--- a/tests/wpunit/CaptchaFieldTest.php
+++ b/tests/wpunit/CaptchaFieldTest.php
@@ -29,28 +29,32 @@ class CaptchaFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -74,7 +78,7 @@ class CaptchaFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [
 			$this->factory->field->create( $this->property_helper->values ),
 			$this->factory->field->create( $this->captcha_field_helper->values ),
@@ -112,7 +116,7 @@ class CaptchaFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 		/**
 		 * The entire GraphQL query with the form field values added.
 		 */
-	protected function entry_query() : string {
+	protected function entry_query(): string {
 		return "
 			query getFieldValue(\$id: ID!, \$idType: EntryIdTypeEnum) {
 				gfEntry(id: \$id, idType: \$idType ) {
@@ -128,10 +132,8 @@ class CaptchaFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on CaptchaField {
 				displayOnly
@@ -172,10 +174,8 @@ class CaptchaFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 	 * Returns the SubmitForm graphQL query.
 	 *
 	 * The $value can be anything since we're using google's test keys.
-	 *
-	 * @return string
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ($formId: ID!, $fieldId: Int!, $value: String!, $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: [{id: $fieldId, value: $value}, {id:' . $this->fields[1]->id . ' value:"123456"}]}) {
@@ -252,13 +252,11 @@ class CaptchaFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 			}
 		';
 	}
+
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
-	 * @return array
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected = $this->getExpectedFormFieldValues( $form['fields'][1] );
 
 		return [
@@ -279,14 +277,14 @@ class CaptchaFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 			),
 		];
 	}
+
 	/**
 	 * The expected WPGraphQL mutation response.
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,

--- a/tests/wpunit/ChainedSelectFieldTest.php
+++ b/tests/wpunit/ChainedSelectFieldTest.php
@@ -18,28 +18,32 @@ class ChainedSelectFieldTest extends FormFieldTestCase implements FormFieldTestC
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -53,7 +57,7 @@ class ChainedSelectFieldTest extends FormFieldTestCase implements FormFieldTestC
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [ $this->factory->field->create( $this->property_helper->values ) ];
 	}
 
@@ -63,6 +67,7 @@ class ChainedSelectFieldTest extends FormFieldTestCase implements FormFieldTestC
 	public function field_value() {
 		return [ '2015', 'Acura', 'MDX' ];
 	}
+
 	/**
 	 * The graphql field value input.
 	 */
@@ -82,7 +87,6 @@ class ChainedSelectFieldTest extends FormFieldTestCase implements FormFieldTestC
 			],
 		];
 	}
-
 
 	/**
 	 * The value as expected in GraphQL when updating from field_value().
@@ -124,13 +128,10 @@ class ChainedSelectFieldTest extends FormFieldTestCase implements FormFieldTestC
 		];
 	}
 
-
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query():string {
+	public function field_query(): string {
 		return '
 			... on ChainedSelectField {
 				adminLabel
@@ -277,9 +278,7 @@ class ChainedSelectFieldTest extends FormFieldTestCase implements FormFieldTestC
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
 	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
@@ -309,9 +308,8 @@ class ChainedSelectFieldTest extends FormFieldTestCase implements FormFieldTestC
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ):array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,

--- a/tests/wpunit/CheckboxFieldTest.php
+++ b/tests/wpunit/CheckboxFieldTest.php
@@ -17,28 +17,32 @@ class CheckboxFieldTest extends FormFieldTestCase implements FormFieldTestCaseIn
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -52,7 +56,7 @@ class CheckboxFieldTest extends FormFieldTestCase implements FormFieldTestCaseIn
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [ $this->factory->field->create( $this->property_helper->values ) ];
 	}
 
@@ -168,7 +172,6 @@ class CheckboxFieldTest extends FormFieldTestCase implements FormFieldTestCaseIn
 		];
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -179,13 +182,10 @@ class CheckboxFieldTest extends FormFieldTestCase implements FormFieldTestCaseIn
 		];
 	}
 
-
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query():string {
+	public function field_query(): string {
 		return '
 			... on CheckboxField {
 				adminLabel
@@ -360,9 +360,7 @@ class CheckboxFieldTest extends FormFieldTestCase implements FormFieldTestCaseIn
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
 	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
@@ -392,9 +390,8 @@ class CheckboxFieldTest extends FormFieldTestCase implements FormFieldTestCaseIn
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ):array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,

--- a/tests/wpunit/ConsentFieldTest.php
+++ b/tests/wpunit/ConsentFieldTest.php
@@ -18,28 +18,32 @@ class ConsentFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -53,7 +57,7 @@ class ConsentFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [ $this->factory->field->create( $this->property_helper->values ) ];
 	}
 
@@ -106,10 +110,8 @@ class ConsentFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query():string {
+	public function field_query(): string {
 		return '
 			... on ConsentField {
 				adminLabel
@@ -222,9 +224,7 @@ class ConsentFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
 	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
@@ -254,9 +254,8 @@ class ConsentFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ):array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,

--- a/tests/wpunit/DateFieldTest.php
+++ b/tests/wpunit/DateFieldTest.php
@@ -17,30 +17,35 @@ class DateFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
+
 	/**
 	 * Sets the correct Field Helper.
 	 */
@@ -51,7 +56,7 @@ class DateFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [ $this->factory->field->create( $this->property_helper->values ) ];
 	}
 
@@ -69,7 +74,6 @@ class DateFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 		return $this->property_helper->dummy->ymd();
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -79,10 +83,8 @@ class DateFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on DateField {
 				adminLabel
@@ -135,7 +137,7 @@ class DateFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	/**
 	 * SubmitForm mutation string.
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ( $formId: ID!, $fieldId: Int!, $value: String!, $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: {id: $fieldId, value: $value}}) {
@@ -166,7 +168,7 @@ class DateFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	/**
 	 * Returns the UpdateEntry mutation string.
 	 */
-	public function update_entry_mutation() : string {
+	public function update_entry_mutation(): string {
 		return '
 			mutation updateGfEntry( $entryId: ID!, $fieldId: Int!, $value: String! ){
 				updateGfEntry( input: { id: $entryId, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -191,7 +193,7 @@ class DateFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
 	 */
-	public function update_draft_entry_mutation() : string {
+	public function update_draft_entry_mutation(): string {
 		return '
 			mutation updateGfDraftEntry( $resumeToken: ID!, $fieldId: Int!, $value: String! ){
 				updateGfDraftEntry( input: {id: $resumeToken, idType: RESUME_TOKEN, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -214,11 +216,9 @@ class DateFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
 		$expected[] = $this->expected_field_value( 'value', $this->field_value );
 
@@ -246,9 +246,8 @@ class DateFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,
@@ -280,7 +279,7 @@ class DateFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	 * @param array $actual_entry .
 	 * @param array $form .
 	 */
-	public function check_saved_values( $actual_entry, $form ) : void {
+	public function check_saved_values( $actual_entry, $form ): void {
 		$this->assertEquals( $this->field_value, $actual_entry[ $form['fields'][0]->id ], 'Submit mutation entry value not equal' );
 	}
 }

--- a/tests/wpunit/DeleteDraftEntryMutationTest.php
+++ b/tests/wpunit/DeleteDraftEntryMutationTest.php
@@ -17,7 +17,6 @@ class DeleteDraftEntryMutationTest extends GFGraphQLTestCase {
 	private $draft_token;
 	private $text_field_helper;
 
-
 	/**
 	 * Run before each test.
 	 */
@@ -55,7 +54,7 @@ class DeleteDraftEntryMutationTest extends GFGraphQLTestCase {
 	/**
 	 * Tests `deleteGfDraftEntry`.
 	 */
-	public function testDeleteGfDraftEntry() : void {
+	public function testDeleteGfDraftEntry(): void {
 		$query = $this->delete_mutation();
 
 		$variables = [
@@ -85,7 +84,7 @@ class DeleteDraftEntryMutationTest extends GFGraphQLTestCase {
 	/**
 	 * Tests `deleteGfDraftEntry`.
 	 */
-	public function testDeleteGfDraftEntry_globalId() : void {
+	public function testDeleteGfDraftEntry_globalId(): void {
 		$query = $this->delete_mutation();
 
 		// Test Global Id
@@ -108,7 +107,7 @@ class DeleteDraftEntryMutationTest extends GFGraphQLTestCase {
 	/**
 	 * Tests `deleteGfDraftEntry` when a bad resumeToken is supplied.
 	 */
-	public function testDeleteGfDraftEntry_badToken() : void {
+	public function testDeleteGfDraftEntry_badToken(): void {
 		wp_set_current_user( $this->admin->ID );
 
 		$query = $this->delete_mutation();
@@ -124,12 +123,13 @@ class DeleteDraftEntryMutationTest extends GFGraphQLTestCase {
 
 		$this->factory->draft_entry->delete( $this->draft_token );
 	}
+
 	/**
 	 * Creates the mutation.
 	 *
 	 * @param array $args .
 	 */
-	public function delete_mutation() : string {
+	public function delete_mutation(): string {
 		return '
 			mutation deleteGfDraftEntry(
 				$id: ID!,

--- a/tests/wpunit/DeleteEntryMutationTest.php
+++ b/tests/wpunit/DeleteEntryMutationTest.php
@@ -57,7 +57,7 @@ class DeleteEntryMutationTest extends GFGraphQLTestCase {
 	/**
 	 * Tests `deleteGfEntry`.
 	 */
-	public function testDeleteGfEntry() : void {
+	public function testDeleteGfEntry(): void {
 		$query = $this->delete_mutation();
 
 		$variables = [
@@ -101,7 +101,7 @@ class DeleteEntryMutationTest extends GFGraphQLTestCase {
 	/**
 	 * Tests `deleteGfEntry` when a bad entryId is supplied.
 	 */
-	public function testDeleteGfEntry_badToken() : void {
+	public function testDeleteGfEntry_badToken(): void {
 		$query = $this->delete_mutation();
 
 		// Test Global Id
@@ -127,7 +127,7 @@ class DeleteEntryMutationTest extends GFGraphQLTestCase {
 	 *
 	 * @param array $args .
 	 */
-	public function delete_mutation( array $args = [] ) : string {
+	public function delete_mutation( array $args = [] ): string {
 		return '
 			mutation deleteGfEntry(
 				$id: ID!,

--- a/tests/wpunit/EmailFieldTest.php
+++ b/tests/wpunit/EmailFieldTest.php
@@ -12,37 +12,41 @@ use Tests\WPGraphQL\GF\TestCase\FormFieldTestCaseInterface;
  * Class -EmailFieldTest.
  */
 class EmailFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterface {
-
 	/**
 	 * Tests the field properties and values.
 	 */
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
+
 	/**
 	 * Sets the correct Field Helper.
 	 */
@@ -53,7 +57,7 @@ class EmailFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [ $this->factory->field->create( $this->property_helper->values ) ];
 	}
 
@@ -93,7 +97,6 @@ class EmailFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 		];
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -103,10 +106,8 @@ class EmailFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on EmailField {
 				adminLabel
@@ -157,7 +158,7 @@ class EmailFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 	/**
 	 * SubmitForm mutation string.
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ( $formId: ID!, $fieldId: Int!, $value: EmailFieldInput!, $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: {id: $fieldId, emailValues: $value}}) {
@@ -188,7 +189,7 @@ class EmailFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 	/**
 	 * Returns the UpdateEntry mutation string.
 	 */
-	public function update_entry_mutation() : string {
+	public function update_entry_mutation(): string {
 		return '
 			mutation updateGfEntry( $entryId: ID!, $fieldId: Int!, $value: EmailFieldInput! ){
 				updateGfEntry( input: { id: $entryId, shouldValidate: true, fieldValues: {id: $fieldId, emailValues: $value} }) {
@@ -213,7 +214,7 @@ class EmailFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
 	 */
-	public function update_draft_entry_mutation() : string {
+	public function update_draft_entry_mutation(): string {
 		return '
 			mutation updateGfDraftEntry( $resumeToken: ID!, $fieldId: Int!, $value: EmailFieldInput! ){
 				updateGfDraftEntry( input: {id: $resumeToken, idType: RESUME_TOKEN, shouldValidate: true, fieldValues: {id: $fieldId, emailValues: $value} }) {
@@ -236,11 +237,9 @@ class EmailFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
 		$expected[] = $this->expected_field_value( 'value', $this->field_value );
 
@@ -268,9 +267,8 @@ class EmailFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,
@@ -302,7 +300,7 @@ class EmailFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 	 * @param array $actual_entry .
 	 * @param array $form .
 	 */
-	public function check_saved_values( $actual_entry, $form ) : void {
+	public function check_saved_values( $actual_entry, $form ): void {
 		$this->assertEquals( $this->field_value, $actual_entry[ $form['fields'][0]->id ], 'Submit mutation entry value not equal' );
 	}
 }

--- a/tests/wpunit/EntryConnectionQueriesTest.php
+++ b/tests/wpunit/EntryConnectionQueriesTest.php
@@ -5,12 +5,7 @@
  * @package .
  */
 
-use GraphQLRelay\Relay;
 use Tests\WPGraphQL\GF\TestCase\GFGraphQLTestCase;
-use WPGraphQL\GF\Type\Enum;
-use Helper\GFHelpers\GFHelpers;
-use WPGraphQL\GF\Data\Loader\DraftEntriesLoader;
-use WPGraphQL\GF\Data\Loader\EntriesLoader;
 
 /**
  * Class - EntryConnectionQueriesTest
@@ -67,7 +62,7 @@ class EntryConnectionQueriesTest extends GFGraphQLTestCase {
 	/**
 	 * Tests `gfEntries`.
 	 */
-	public function testEntriesQuery() : void {
+	public function testEntriesQuery(): void {
 		wp_set_current_user( $this->admin->ID );
 
 		$query = '
@@ -132,7 +127,7 @@ class EntryConnectionQueriesTest extends GFGraphQLTestCase {
 	/**
 	 * Tests the form->entries connection only contains entries on the form.
 	 */
-	public function testFormOnlyContainsRelatedEntries() : void {
+	public function testFormOnlyContainsRelatedEntries(): void {
 		$form_id = $this->factory->form->create(
 			array_merge(
 				[ 'fields' => $this->fields ],

--- a/tests/wpunit/EntryQueriesTest.php
+++ b/tests/wpunit/EntryQueriesTest.php
@@ -6,11 +6,11 @@
  */
 
 use GraphQLRelay\Relay;
-use Tests\WPGraphQL\GF\TestCase\GFGraphQLTestCase;
-use WPGraphQL\GF\Type\Enum;
 use Helper\GFHelpers\GFHelpers;
+use Tests\WPGraphQL\GF\TestCase\GFGraphQLTestCase;
 use WPGraphQL\GF\Data\Loader\DraftEntriesLoader;
 use WPGraphQL\GF\Data\Loader\EntriesLoader;
+use WPGraphQL\GF\Type\Enum;
 
 /**
  * Class - EntryQueriesTest
@@ -65,10 +65,8 @@ class EntryQueriesTest extends GFGraphQLTestCase {
 
 	/**
 	 * Returns the full entry query for reuse.
-	 *
-	 * @return string
 	 */
-	private function get_entry_query() : string {
+	private function get_entry_query(): string {
 		return '
 			query getEntry($id: ID!, $idType: EntryIdTypeEnum) {
 				gfEntry(id: $id, idType: $idType) {
@@ -115,7 +113,7 @@ class EntryQueriesTest extends GFGraphQLTestCase {
 	/**
 	 * Tests `gfEntry`.
 	 */
-	public function testEntryQuery() : void {
+	public function testEntryQuery(): void {
 		wp_set_current_user( $this->admin->ID );
 
 		$global_id = Relay::toGlobalId( EntriesLoader::$name, $this->entry_id );
@@ -192,7 +190,7 @@ class EntryQueriesTest extends GFGraphQLTestCase {
 	/**
 	 * Tests `gfEntry` with draft entry.
 	 */
-	public function testDraftEntryQuery() : void {
+	public function testDraftEntryQuery(): void {
 		wp_set_current_user( $this->admin->ID );
 
 		$draft_token = $this->factory->draft_entry->create(
@@ -249,34 +247,31 @@ class EntryQueriesTest extends GFGraphQLTestCase {
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
-	 * @return array
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $entry, array $form ) : array {
+	public function expected_field_response( array $entry, array $form ): array {
 		return [
 			$this->expectedObject(
 				'gfEntry',
 				[
-					$this->expectedField( 'createdByDatabaseId', ! empty( $entry['created_by'] ) ? (int) $entry['created_by'] : static::IS_NULL ),
-					$this->expectedField( 'createdById', ! empty( $entry['created_by'] ) ? $this->toRelayId( 'user', $entry['created_by'] ) : static::IS_NULL ),
+					$this->expectedField( 'createdByDatabaseId', ! empty( $entry['created_by'] ) ? (int) $entry['created_by'] : self::IS_NULL ),
+					$this->expectedField( 'createdById', ! empty( $entry['created_by'] ) ? $this->toRelayId( 'user', $entry['created_by'] ) : self::IS_NULL ),
 					$this->expectedObject(
 						'createdBy',
 						[
-							$this->expectedField( 'databaseId', ! empty( $entry['created_by'] ) ? (int) $entry['created_by'] : static::IS_NULL ),
+							$this->expectedField( 'databaseId', ! empty( $entry['created_by'] ) ? (int) $entry['created_by'] : self::IS_NULL ),
 						]
 					),
-					$this->expectedField( 'databaseId', ! empty( $entry['id'] ) ? (int) $entry['id'] : static::IS_NULL ),
-					$this->expectedField( 'dateCreated', ! empty( $entry['date_created'] ) ? get_date_from_gmt( $entry['date_created'] ) : static::IS_NULL ),
-					$this->expectedField( 'dateCreatedGmt', ! empty( $entry['date_created'] ) ? $entry['date_created'] : static::IS_NULL ),
-					$this->expectedField( 'dateUpdated', ! empty( $entry['date_updated'] ) ? get_date_from_gmt( $entry['date_updated'] ) : static::IS_NULL ),
-					$this->expectedField( 'dateUpdatedGmt', ! empty( $entry['date_updated'] ) ? $entry['date_updated'] : static::IS_NULL ),
-					$this->expectedField( 'formDatabaseId', ! empty( $form['id'] ) ? (int) $form['id'] : static::IS_NULL ),
+					$this->expectedField( 'databaseId', ! empty( $entry['id'] ) ? (int) $entry['id'] : self::IS_NULL ),
+					$this->expectedField( 'dateCreated', ! empty( $entry['date_created'] ) ? get_date_from_gmt( $entry['date_created'] ) : self::IS_NULL ),
+					$this->expectedField( 'dateCreatedGmt', ! empty( $entry['date_created'] ) ? $entry['date_created'] : self::IS_NULL ),
+					$this->expectedField( 'dateUpdated', ! empty( $entry['date_updated'] ) ? get_date_from_gmt( $entry['date_updated'] ) : self::IS_NULL ),
+					$this->expectedField( 'dateUpdatedGmt', ! empty( $entry['date_updated'] ) ? $entry['date_updated'] : self::IS_NULL ),
+					$this->expectedField( 'formDatabaseId', ! empty( $form['id'] ) ? (int) $form['id'] : self::IS_NULL ),
 					$this->expectedObject(
 						'form',
 						[
-							$this->expectedField( 'databaseId', isset( $form['id'] ) ? (int) $form['id'] : static::IS_NULL ),
+							$this->expectedField( 'databaseId', isset( $form['id'] ) ? (int) $form['id'] : self::IS_NULL ),
 						]
 					),
 					$this->expectedObject(
@@ -292,15 +287,15 @@ class EntryQueriesTest extends GFGraphQLTestCase {
 						]
 					),
 					$this->expectedField( 'id', $this->toRelayId( EntriesLoader::$name, $entry['id'] ) ),
-					$this->expectedField( 'ip', ! empty( $entry['ip'] ) ? $entry['ip'] : static::IS_NULL ),
+					$this->expectedField( 'ip', ! empty( $entry['ip'] ) ? $entry['ip'] : self::IS_NULL ),
 					$this->expectedField( 'isDraft', ! empty( $entry['resume_token'] ) ),
 					$this->expectedField( 'isSubmitted', ! empty( $entry['id'] ) ),
 					$this->expectedField( 'isRead', ! empty( $entry['is_read'] ) ),
 					$this->expectedField( 'isStarred', ! empty( $entry['isStarred'] ) ),
-					$this->expectedField( 'resumeToken', ! empty( $entry['resumeToken'] ) ? $entry['resumeToken'] : static::IS_NULL ),
-					$this->expectedField( 'sourceUrl', ! empty( $entry['source_url'] ) ? $entry['source_url'] : static::IS_NULL ),
-					$this->expectedField( 'status', ! empty( $entry['status'] ) ? GFHelpers::get_enum_for_value( Enum\EntryStatusEnum::$type, $entry['status'] ) : static::IS_NULL ),
-					$this->expectedField( 'userAgent', ! empty( $entry['user_agent'] ) ? $entry['user_agent'] : static::IS_NULL ),
+					$this->expectedField( 'resumeToken', ! empty( $entry['resumeToken'] ) ? $entry['resumeToken'] : self::IS_NULL ),
+					$this->expectedField( 'sourceUrl', ! empty( $entry['source_url'] ) ? $entry['source_url'] : self::IS_NULL ),
+					$this->expectedField( 'status', ! empty( $entry['status'] ) ? GFHelpers::get_enum_for_value( Enum\EntryStatusEnum::$type, $entry['status'] ) : self::IS_NULL ),
+					$this->expectedField( 'userAgent', ! empty( $entry['user_agent'] ) ? $entry['user_agent'] : self::IS_NULL ),
 				]
 			),
 		];

--- a/tests/wpunit/FileUploadFieldTest.php
+++ b/tests/wpunit/FileUploadFieldTest.php
@@ -74,28 +74,32 @@ class FileUploadFieldTest extends FormFieldTestCase implements FormFieldTestCase
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -109,7 +113,7 @@ class FileUploadFieldTest extends FormFieldTestCase implements FormFieldTestCase
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [ $this->factory->field->create( $this->property_helper->values ) ];
 	}
 
@@ -182,10 +186,8 @@ class FileUploadFieldTest extends FormFieldTestCase implements FormFieldTestCase
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on FileUploadField {
 				adminLabel
@@ -225,10 +227,8 @@ class FileUploadFieldTest extends FormFieldTestCase implements FormFieldTestCase
 
 	/**
 	 * SubmitForm mutation string.
-	 *
-	 * @return string
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ($formId: ID!, $fieldId: Int!, $value: [Upload!], $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: {id: $fieldId, fileUploadValues: $value}}) {
@@ -262,8 +262,6 @@ class FileUploadFieldTest extends FormFieldTestCase implements FormFieldTestCase
 
 	/**
 	 * Returns the UpdateEntry mutation string.
-	 *
-	 * @return string
 	 */
 	public function update_entry_mutation(): string {
 		return '
@@ -293,8 +291,6 @@ class FileUploadFieldTest extends FormFieldTestCase implements FormFieldTestCase
 
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
-	 *
-	 * @return string
 	 */
 	public function update_draft_entry_mutation(): string {
 		return '
@@ -321,13 +317,11 @@ class FileUploadFieldTest extends FormFieldTestCase implements FormFieldTestCase
 			}
 		';
 	}
+
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
-	 * @return array
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected = $this->getExpectedFormFieldValues( $form['fields'][0] );
 
 		$expected_field_value    = $this->field_value;
@@ -364,9 +358,8 @@ class FileUploadFieldTest extends FormFieldTestCase implements FormFieldTestCase
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		$form = $this->factory->form->get_object_by_id( $this->form_id );
 
 		$url = ! $this->is_draft ? $this->factory->entry->get_object_by_id( $this->entry_id )[ $form['fields'][0]->id ] : null;

--- a/tests/wpunit/FileUploadMultipleFieldTest.php
+++ b/tests/wpunit/FileUploadMultipleFieldTest.php
@@ -15,29 +15,29 @@ use WPGraphQL\GF\Utils\GFUtils;
  * Class -FileUploadMultipleFieldTest
  */
 class FileUploadMultipleFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterface {
-
 	/**
 	 * Set up.
 	 */
 	public function setUp(): void {
 		// Before...
 
-		copy( dirname( __FILE__ ) . '/../_support/files/img1.png', '/tmp/img1.png' );
+		copy( __DIR__ . '/../_support/files/img1.png', '/tmp/img1.png' );
 		$stat  = stat( dirname( '/tmp/img1.png' ) );
 		$perms = $stat['mode'] & 0000666;
 		chmod( '/tmp/img1.png', $perms );
-		copy( dirname( __FILE__ ) . '/../_support/files/img2.png', '/tmp/img2.png' );
+		copy( __DIR__ . '/../_support/files/img2.png', '/tmp/img2.png' );
 		$stat  = stat( dirname( '/tmp/img2.png' ) );
 		$perms = $stat['mode'] & 0000666;
 		chmod( '/tmp/img2.png', $perms );
-		copy( dirname( __FILE__ ) . '/../_support/files/img2.png', '/tmp/img3.png' );
+		copy( __DIR__ . '/../_support/files/img2.png', '/tmp/img3.png' );
 		$stat  = stat( dirname( '/tmp/img3.png' ) );
 		$perms = $stat['mode'] & 0000666;
 		chmod( '/tmp/img3.png', $perms );
-		copy( dirname( __FILE__ ) . '/../_support/files/img2.png', '/tmp/img4.png' );
+		copy( __DIR__ . '/../_support/files/img2.png', '/tmp/img4.png' );
 		$stat  = stat( dirname( '/tmp/img4.png' ) );
 		$perms = $stat['mode'] & 0000666;
 		chmod( '/tmp/img4.png', $perms );
+
 		parent::setUp();
 
 		global $_gf_uploaded_files;
@@ -46,36 +46,42 @@ class FileUploadMultipleFieldTest extends FormFieldTestCase implements FormField
 
 	public function tearDown(): void {
 		GFFormsModel::delete_files( $this->entry_id, $this->factory->form->get_object_by_id( $this->form_id ) );
+
 		parent::tearDown();
 	}
+
 	/**
 	 * Tests the field properties and values.
 	 */
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -89,7 +95,7 @@ class FileUploadMultipleFieldTest extends FormFieldTestCase implements FormField
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [ $this->factory->field->create( $this->property_helper->values ) ];
 	}
 
@@ -191,10 +197,8 @@ class FileUploadMultipleFieldTest extends FormFieldTestCase implements FormField
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on FileUploadField {
 				adminLabel
@@ -234,10 +238,8 @@ class FileUploadMultipleFieldTest extends FormFieldTestCase implements FormField
 
 	/**
 	 * SubmitForm mutation string.
-	 *
-	 * @return string
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ($formId: ID!, $fieldId: Int!, $value: [Upload!], $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: {id: $fieldId, fileUploadValues: $value}}) {
@@ -271,8 +273,6 @@ class FileUploadMultipleFieldTest extends FormFieldTestCase implements FormField
 
 	/**
 	 * Returns the UpdateEntry mutation string.
-	 *
-	 * @return string
 	 */
 	public function update_entry_mutation(): string {
 		return '
@@ -302,8 +302,6 @@ class FileUploadMultipleFieldTest extends FormFieldTestCase implements FormField
 
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
-	 *
-	 * @return string
 	 */
 	public function update_draft_entry_mutation(): string {
 		return '
@@ -330,13 +328,11 @@ class FileUploadMultipleFieldTest extends FormFieldTestCase implements FormField
 			}
 		';
 	}
+
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
-	 * @return array
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected = $this->getExpectedFormFieldValues( $form['fields'][0] );
 
 		$urls = json_decode( $this->factory->entry->get_object_by_id( $this->entry_id )[ $form['fields'][0]->id ] );
@@ -377,9 +373,8 @@ class FileUploadMultipleFieldTest extends FormFieldTestCase implements FormField
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		$form = $this->factory->form->get_object_by_id( $this->form_id );
 
 		$urls = ! $this->is_draft ? json_decode( $this->factory->entry->get_object_by_id( $this->entry_id )[ $form['fields'][0]->id ] ) : [];

--- a/tests/wpunit/FormConnectionQueriesTest.php
+++ b/tests/wpunit/FormConnectionQueriesTest.php
@@ -233,7 +233,6 @@ class FormConnectionQueriesTest extends GFGraphQLTestCase {
 		$this->assertEqualSets( $expected['data']['gfForms']['nodes'], $actual['data']['gfForms']['nodes'] );
 	}
 
-
 	public function testFormIdsWhereArgs() {
 		$form_id_two = $this->form_ids[2];
 		$form_id_one = $this->form_ids[1];

--- a/tests/wpunit/FormQueriesTest.php
+++ b/tests/wpunit/FormQueriesTest.php
@@ -6,11 +6,11 @@
  */
 
 use GraphQLRelay\Relay;
-use Tests\WPGraphQL\GF\TestCase\GFGraphQLTestCase;
-use WPGraphQL\GF\Type\Enum;
-use WPGraphQL\GF\Extensions\GFQuiz\Type\Enum as QuizEnum;
 use Helper\GFHelpers\GFHelpers;
+use Tests\WPGraphQL\GF\TestCase\GFGraphQLTestCase;
 use WPGraphQL\GF\Data\Loader\FormsLoader;
+use WPGraphQL\GF\Extensions\GFQuiz\Type\Enum as QuizEnum;
+use WPGraphQL\GF\Type\Enum;
 
 /**
  * Class - FormQueriesTest
@@ -59,7 +59,7 @@ class FormQueriesTest extends GFGraphQLTestCase {
 	/**
 	 * Tests `gfForm`.
 	 */
-	public function testFormQuery() : void {
+	public function testFormQuery(): void {
 		$global_id        = Relay::toGlobalId( FormsLoader::$name, $this->form_id );
 		$form             = GFAPI::get_form( $this->form_id );
 		$confirmation_key = key( $form['confirmations'] );
@@ -105,7 +105,7 @@ class FormQueriesTest extends GFGraphQLTestCase {
 	/**
 	 * Returns the full form query for reuse.
 	 */
-	private function get_form_query() : string {
+	private function get_form_query(): string {
 		return '
 			query getForm( $id: ID!, $idType: FormIdTypeEnum ) {
 				gfForm( id: $id, idType: $idType ) {
@@ -308,12 +308,9 @@ class FormQueriesTest extends GFGraphQLTestCase {
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
-	 * @return array
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form, string $confirmation_key ) : array {
+	public function expected_field_response( array $form, string $confirmation_key ): array {
 		return [
 			$this->expectedObject(
 				'gfForm',
@@ -338,7 +335,7 @@ class FormQueriesTest extends GFGraphQLTestCase {
 							$this->expectedField( 'isDefault', $form['confirmations'][ $confirmation_key ]['isDefault'] ),
 							$this->expectedField( 'message', $form['confirmations'][ $confirmation_key ]['message'] ),
 							$this->expectedField( 'name', $form['confirmations'][ $confirmation_key ]['name'] ),
-							$this->expectedField( 'pageId', $form['confirmations'][ $confirmation_key ]['pageId'] ?? static::IS_NULL ),
+							$this->expectedField( 'pageId', $form['confirmations'][ $confirmation_key ]['pageId'] ?? self::IS_NULL ),
 							$this->expectedField( 'queryString', $form['confirmations'][ $confirmation_key ]['queryString'] ),
 							$this->expectedField( 'type', GFHelpers::get_enum_for_value( Enum\FormConfirmationTypeEnum::$type, $form['confirmations'][ $confirmation_key ]['type'] ) ),
 							$this->expectedField( 'url', $form['confirmations'][ $confirmation_key ]['url'] ),
@@ -519,7 +516,7 @@ class FormQueriesTest extends GFGraphQLTestCase {
 								]
 							),
 							// This is null, since grading type is PASSFAIL.
-							$this->expectedField( 'grades', static::IS_NULL ),
+							$this->expectedField( 'grades', self::IS_NULL ),
 							// $this->expectedNode(
 							// 'grades',
 							// [
@@ -531,11 +528,11 @@ class FormQueriesTest extends GFGraphQLTestCase {
 							$this->expectedField( 'gradingType', GFHelpers::get_enum_for_value( QuizEnum\QuizFieldGradingTypeEnum::$type, $form['gravityformsquiz']['grading'] ) ),
 							$this->expectedField( 'hasInstantFeedback', ! empty( $form['gravityformsquiz']['instantFeedback'] ) ),
 							// This is null because grading type is PASSFAIL.
-							$this->expectedField( 'hasLetterConfirmationMessage', static::IS_NULL ),
+							$this->expectedField( 'hasLetterConfirmationMessage', self::IS_NULL ),
 							$this->expectedField( 'hasPassFailConfirmationMessage', ! empty( $form['gravityformsquiz']['passfailDisplayConfirmation'] ) ),
 							$this->expectedField( 'isShuffleFieldsEnabled', ! empty( $form['gravityformsquiz']['shuffleFields'] ) ),
-							$this->expectedField( 'letterConfirmation', static::IS_NULL ),
-							$this->expectedField( 'maxScore', static::IS_NULL ),
+							$this->expectedField( 'letterConfirmation', self::IS_NULL ),
+							$this->expectedField( 'maxScore', self::IS_NULL ),
 							$this->expectedObject(
 								'passConfirmation',
 								[

--- a/tests/wpunit/GFTest.php
+++ b/tests/wpunit/GFTest.php
@@ -12,6 +12,7 @@ class GFTest extends \Codeception\TestCase\WPTestCase {
 	public function setUp(): void {
 		// Before...
 		parent::setUp();
+
 		\WPGraphQL::clear_schema();
 	}
 

--- a/tests/wpunit/GFUtilsTest.php
+++ b/tests/wpunit/GFUtilsTest.php
@@ -6,8 +6,8 @@
  */
 
 use GraphQL\Error\UserError;
-use WPGraphQL\GF\Utils\GFUtils;
 use Tests\WPGraphQL\GF\TestCase\GFGraphQLTestCase;
+use WPGraphQL\GF\Utils\GFUtils;
 
 /**
  * Class - GFUtilsTest
@@ -60,7 +60,7 @@ class GFUtilsTest extends GFGraphQLTestCase {
 	/**
 	 * Tests GFUtils::get_ip().
 	 */
-	public function testGetIp() : void {
+	public function testGetIp(): void {
 		$ip = '192.168.0.1';
 
 		$actual = GFUtils::get_ip( $ip );
@@ -75,7 +75,7 @@ class GFUtilsTest extends GFGraphQLTestCase {
 	/**
 	 * Tests GFUtils::get_form().
 	 */
-	public function testGetForm() : void {
+	public function testGetForm(): void {
 		$expected = $this->factory->form->get_object_by_id( $this->form_id );
 
 		// No second parameter.
@@ -88,12 +88,10 @@ class GFUtilsTest extends GFGraphQLTestCase {
 		$actual = GFUtils::get_form( $this->form_id + 1 );
 	}
 
-
-
 	/**
 	 * Tests GFUtils::get_form() for trashed forms.
 	 */
-	public function testGetForm_trash() : void {
+	public function testGetForm_trash(): void {
 		// Create Trash Entry.
 		$form_id    = $this->factory->form->create( array_merge( [ 'fields' => $this->fields ], $this->tester->getFormDefaultArgs() ) );
 		$is_updated = \GFFormsModel::trash_form( $form_id );
@@ -113,7 +111,7 @@ class GFUtilsTest extends GFGraphQLTestCase {
 	/**
 	 * Tests GFUtils::get_forms().
 	 */
-	public function testGetForms() : void {
+	public function testGetForms(): void {
 		$expected = $this->factory->form->get_object_by_id( $this->form_id );
 
 		$actual = GFUtils::get_forms( [ $this->form_id ] );
@@ -123,7 +121,7 @@ class GFUtilsTest extends GFGraphQLTestCase {
 	/**
 	 * Tests GFUtils::get_last_form_page().
 	 */
-	public function testGetLastFormPage() : void {
+	public function testGetLastFormPage(): void {
 		$this->markTestIncomplete(
 			'This test has not been implemented yet. Requires PageField arguments.'
 		);
@@ -132,7 +130,7 @@ class GFUtilsTest extends GFGraphQLTestCase {
 	/**
 	 * Tests GFUtils::get_form_unique_id().
 	 */
-	public function testGetFormUniqueId() : void {
+	public function testGetFormUniqueId(): void {
 		$expected = GFUtils::get_form_unique_id( $this->form_id );
 		$actual   = GFUtils::get_form_unique_id( $this->form_id );
 		$this->assertEquals( $expected, $actual );
@@ -141,7 +139,7 @@ class GFUtilsTest extends GFGraphQLTestCase {
 	/**
 	 * Tests GFUtils::get_field_by_id().
 	 */
-	public function testGetFieldById() : void {
+	public function testGetFieldById(): void {
 		$form     = $this->factory->form->get_object_by_id( $this->form_id );
 		$expected = $this->fields[0];
 		$actual   = GFUtils::get_field_by_id( $form, $this->fields[0]->id );
@@ -158,7 +156,7 @@ class GFUtilsTest extends GFGraphQLTestCase {
 	/**
 	 * Tests GFUtils::get_entry().
 	 */
-	public function testGetEntry() : void {
+	public function testGetEntry(): void {
 		$expected = $this->factory->entry->get_object_by_id( $this->entry_id );
 		$actual   = GFUtils::get_entry( $this->entry_id );
 		$this->assertEquals( $expected, $actual );
@@ -172,7 +170,7 @@ class GFUtilsTest extends GFGraphQLTestCase {
 	/**
 	 * Tests GFUtils::update_entry().
 	 */
-	public function testUpdateEntry() : void {
+	public function testUpdateEntry(): void {
 		$entry_data = $this->factory->entry->get_object_by_id( $this->entry_id );
 
 		$entry_data['is_starred'] = true;
@@ -192,7 +190,7 @@ class GFUtilsTest extends GFGraphQLTestCase {
 	/**
 	 * Tests GFUtils::get_draft_entry().
 	 */
-	public function testGetDraftEntry() : void {
+	public function testGetDraftEntry(): void {
 		$expected = $this->factory->draft_entry->get_object_by_id( $this->draft_token );
 		$actual   = GFUtils::get_draft_entry( $this->draft_token );
 		$this->assertEquals( $expected, $actual );
@@ -206,7 +204,7 @@ class GFUtilsTest extends GFGraphQLTestCase {
 	/**
 	 * Tests GFUtils::get_draft_submission().
 	 */
-	public function testGetDraftSubmission() : void {
+	public function testGetDraftSubmission(): void {
 		$expected_entry = $this->factory->draft_entry->get_object_by_id( $this->draft_token );
 		$expected       = json_decode( $expected_entry['submission'], true );
 
@@ -219,7 +217,7 @@ class GFUtilsTest extends GFGraphQLTestCase {
 	/**
 	 * Tests GFUtils::get_resume_url().
 	 */
-	public function testGetResumeUrl() : void {
+	public function testGetResumeUrl(): void {
 		$url      = site_url();
 		$expected = $url . '?gf_token=' . $this->draft_token;
 		$actual   = GFUtils::get_resume_url( $this->draft_token, $url );
@@ -232,7 +230,7 @@ class GFUtilsTest extends GFGraphQLTestCase {
 	/**
 	 * Tests GFUtils::save_draft_submission();
 	 */
-	public function testSaveDraftSubmission() : void {
+	public function testSaveDraftSubmission(): void {
 		$form       = $this->factory->form->get_object_by_id( $this->form_id );
 		$entry_data = $this->factory->draft_entry->get_object_by_id( $this->draft_token );
 		$submission = json_decode( $entry_data['submission'], true );
@@ -266,7 +264,7 @@ class GFUtilsTest extends GFGraphQLTestCase {
 	/**
 	 * Tests GFUtils::submit_form() when invalid.
 	 */
-	public function testSubmitForm_invalid() : void {
+	public function testSubmitForm_invalid(): void {
 		$form         = $this->factory->form->get_object_by_id( $this->form_id );
 		$input_values = [
 			'input_' . $form['fields'][0]->id => 'value2',
@@ -280,7 +278,7 @@ class GFUtilsTest extends GFGraphQLTestCase {
 	/**
 	 * Tests GFUtils::submit_form().
 	 */
-	public function testSubmitForm() : void {
+	public function testSubmitForm(): void {
 		$form         = $this->factory->form->get_object_by_id( $this->form_id );
 		$input_values = [
 			'input_' . $form['fields'][0]->id => 'value1',

--- a/tests/wpunit/HiddenFieldTest.php
+++ b/tests/wpunit/HiddenFieldTest.php
@@ -11,35 +11,39 @@ use Tests\WPGraphQL\GF\TestCase\FormFieldTestCaseInterface;
 /**
  * Class -HiddenFieldTest.
  */
-class HiddenFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInterface {
+class HiddenFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterface {
 	/**
 	 * Tests the field properties and values.
 	 */
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -53,7 +57,7 @@ class HiddenFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInt
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [ $this->factory->field->create( $this->property_helper->values ) ];
 	}
 
@@ -81,7 +85,7 @@ class HiddenFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInt
 	/**
 	 * The GraphQL query string.
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on HiddenField {
 				canPrepopulate
@@ -101,7 +105,7 @@ class HiddenFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInt
 	/**
 	 * SubmitForm mutation string.
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ($formId: ID!, $fieldId: Int!, $value: String!, $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: {id: $fieldId, value: $value}}) {
@@ -132,7 +136,7 @@ class HiddenFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInt
 	/**
 	 * Returns the UpdateEntry mutation string.
 	 */
-	public function update_entry_mutation() : string {
+	public function update_entry_mutation(): string {
 		return '
 			mutation updateGfEntry( $entryId: ID!, $fieldId: Int!, $value: String! ){
 				updateGfEntry( input: { id: $entryId, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -158,7 +162,7 @@ class HiddenFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInt
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
 	 */
-	public function update_draft_entry_mutation() : string {
+	public function update_draft_entry_mutation(): string {
 		return '
 			mutation updateGfDraftEntry( $resumeToken: ID!, $fieldId: Int!, $value: String! ){
 				updateGfDraftEntry( input: {id: $resumeToken, idType: RESUME_TOKEN, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -181,11 +185,9 @@ class HiddenFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInt
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
 		$expected[] = $this->expected_field_value( 'value', $this->field_value );
 
@@ -213,9 +215,8 @@ class HiddenFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInt
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,
@@ -247,7 +248,7 @@ class HiddenFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInt
 	 * @param array $actual_entry .
 	 * @param array $form .
 	 */
-	public function check_saved_values( $actual_entry, $form ) : void {
+	public function check_saved_values( $actual_entry, $form ): void {
 		$this->assertEquals( $this->field_value, $actual_entry[ $form['fields'][0]->id ], 'Submit mutation entry value not equal' );
 	}
 }

--- a/tests/wpunit/HtmlFieldTest.php
+++ b/tests/wpunit/HtmlFieldTest.php
@@ -28,7 +28,7 @@ class HtmlFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [ $this->factory->field->create( $this->property_helper->values ) ];
 	}
 
@@ -44,7 +44,6 @@ class HtmlFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	public function updated_field_value() {
 		return ''; }
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -53,10 +52,8 @@ class HtmlFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on HtmlField {
 				conditionalLogic {
@@ -79,29 +76,27 @@ class HtmlFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	/**
 	 * SubmitForm mutation string.
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return ''; }
 
 	/**
 	 * Returns the UpdateEntry mutation string.
 	 */
-	public function update_entry_mutation() : string {
+	public function update_entry_mutation(): string {
 		return '';
 	}
 
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
 	 */
-	public function update_draft_entry_mutation() : string {
+	public function update_draft_entry_mutation(): string {
 		return '';
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected = $this->getExpectedFormFieldValues( $form['fields'][0] );
 
 		return [
@@ -128,9 +123,8 @@ class HtmlFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [];
 	}
 
@@ -140,5 +134,5 @@ class HtmlFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	 * @param array $actual_entry .
 	 * @param array $form .
 	 */
-	public function check_saved_values( $actual_entry, $form ) : void {}
+	public function check_saved_values( $actual_entry, $form ): void {}
 }

--- a/tests/wpunit/ListFieldColumnsTest.php
+++ b/tests/wpunit/ListFieldColumnsTest.php
@@ -12,37 +12,42 @@ use Tests\WPGraphQL\GF\TestCase\FormFieldTestCaseInterface;
 /**
  * Class -ListFieldTest.
  */
-class ListFieldColumnsTest  extends FormFieldTestCase implements FormFieldTestCaseInterface {
+class ListFieldColumnsTest extends FormFieldTestCase implements FormFieldTestCaseInterface {
 	/**
 	 * Tests the field properties and values.
 	 */
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
+
 	/**
 	 * Sets the correct Field Helper.
 	 */
@@ -79,7 +84,7 @@ class ListFieldColumnsTest  extends FormFieldTestCase implements FormFieldTestCa
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [ $this->factory->field->create( $this->property_helper->values ) ];
 	}
 
@@ -151,10 +156,8 @@ class ListFieldColumnsTest  extends FormFieldTestCase implements FormFieldTestCa
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on ListField {
 				addIconUrl
@@ -199,7 +202,7 @@ class ListFieldColumnsTest  extends FormFieldTestCase implements FormFieldTestCa
 	/**
 	 * SubmitForm mutation string.
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ($formId: ID!, $fieldId: Int!, $value: [ListFieldInput]!, $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: {id: $fieldId, listValues: $value}}) {
@@ -232,7 +235,7 @@ class ListFieldColumnsTest  extends FormFieldTestCase implements FormFieldTestCa
 	/**
 	 * Returns the UpdateEntry mutation string.
 	 */
-	public function update_entry_mutation() : string {
+	public function update_entry_mutation(): string {
 		return '
 			mutation updateGfEntry( $entryId: ID!, $fieldId: Int!, $value: [ListFieldInput] ){
 				updateGfEntry( input: { id: $entryId, shouldValidate: true, fieldValues: {id: $fieldId, listValues: $value} }) {
@@ -259,7 +262,7 @@ class ListFieldColumnsTest  extends FormFieldTestCase implements FormFieldTestCa
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
 	 */
-	public function update_draft_entry_mutation() : string {
+	public function update_draft_entry_mutation(): string {
 		return '
 			mutation updateGfDraftEntry( $resumeToken: ID!, $fieldId: Int!, $value: [ListFieldInput]! ){
 				updateGfDraftEntry( input: {id: $resumeToken, idType: RESUME_TOKEN, shouldValidate: true, fieldValues: {id: $fieldId, listValues: $value} }) {
@@ -284,11 +287,9 @@ class ListFieldColumnsTest  extends FormFieldTestCase implements FormFieldTestCa
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
 		$expected[] = $this->expected_field_value( 'listValues', $this->field_value );
 
@@ -316,9 +317,8 @@ class ListFieldColumnsTest  extends FormFieldTestCase implements FormFieldTestCa
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,
@@ -350,11 +350,11 @@ class ListFieldColumnsTest  extends FormFieldTestCase implements FormFieldTestCa
 	 * @param array $actual_entry .
 	 * @param array $form .
 	 */
-	public function check_saved_values( $actual_entry, $form ) : void {
+	public function check_saved_values( $actual_entry, $form ): void {
 		$actual_value = maybe_unserialize( $actual_entry[ $form['fields'][0]->id ], true );
 
 		// Convert to GraphQL ListFieldInput
-		$converted_value = array_map( fn( $value) => [ 'values' => array_values( $value ) ], $actual_value );
+		$converted_value = array_map( static fn ( $value ) => [ 'values' => array_values( $value ) ], $actual_value );
 
 		$this->assertEquals( $this->field_value, $converted_value, 'Submit mutation entry value not equal' );
 	}

--- a/tests/wpunit/ListFieldTest.php
+++ b/tests/wpunit/ListFieldTest.php
@@ -19,30 +19,35 @@ class ListFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
+
 	/**
 	 * Sets the correct Field Helper.
 	 */
@@ -53,7 +58,7 @@ class ListFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [ $this->factory->field->create( $this->property_helper->values ) ];
 	}
 
@@ -111,10 +116,8 @@ class ListFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on ListField {
 				addIconUrl
@@ -159,7 +162,7 @@ class ListFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	/**
 	 * SubmitForm mutation string.
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ($formId: ID!, $fieldId: Int!, $value: [ListFieldInput]!, $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: {id: $fieldId, listValues: $value}}) {
@@ -192,7 +195,7 @@ class ListFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	/**
 	 * Returns the UpdateEntry mutation string.
 	 */
-	public function update_entry_mutation() : string {
+	public function update_entry_mutation(): string {
 		return '
 			mutation updateGfEntry( $entryId: ID!, $fieldId: Int!, $value: [ListFieldInput] ){
 				updateGfEntry( input: { id: $entryId, shouldValidate: true, fieldValues: {id: $fieldId, listValues: $value} }) {
@@ -219,7 +222,7 @@ class ListFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
 	 */
-	public function update_draft_entry_mutation() : string {
+	public function update_draft_entry_mutation(): string {
 		return '
 			mutation updateGfDraftEntry( $resumeToken: ID!, $fieldId: Int!, $value: [ListFieldInput]! ){
 				updateGfDraftEntry( input: {id: $resumeToken, idType: RESUME_TOKEN, shouldValidate: true, fieldValues: {id: $fieldId, listValues: $value} }) {
@@ -244,11 +247,9 @@ class ListFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
 		$expected[] = $this->expected_field_value( 'listValues', $this->field_value );
 
@@ -276,9 +277,8 @@ class ListFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,
@@ -310,11 +310,11 @@ class ListFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	 * @param array $actual_entry .
 	 * @param array $form .
 	 */
-	public function check_saved_values( $actual_entry, $form ) : void {
+	public function check_saved_values( $actual_entry, $form ): void {
 		$actual_value = maybe_unserialize( $actual_entry[ $form['fields'][0]->id ], true );
 
 		// Convert to GraphQL ListFieldInput
-		$converted_value = array_map( fn( $value) => [ 'values' => [ $value ] ], $actual_value );
+		$converted_value = array_map( static fn ( $value ) => [ 'values' => [ $value ] ], $actual_value );
 		$this->assertEquals( $this->field_value, $converted_value, 'Submit mutation entry value not equal' );
 	}
 }

--- a/tests/wpunit/MultiSelectFieldTest.php
+++ b/tests/wpunit/MultiSelectFieldTest.php
@@ -18,28 +18,32 @@ class MultiSelectFieldTest extends FormFieldTestCase implements FormFieldTestCas
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -53,7 +57,7 @@ class MultiSelectFieldTest extends FormFieldTestCase implements FormFieldTestCas
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [ $this->factory->field->create( $this->property_helper->values ) ];
 	}
 
@@ -66,7 +70,6 @@ class MultiSelectFieldTest extends FormFieldTestCase implements FormFieldTestCas
 			'third',
 		];
 	}
-
 
 	/**
 	 * The value as expected in GraphQL when updating from field_value().
@@ -84,13 +87,10 @@ class MultiSelectFieldTest extends FormFieldTestCase implements FormFieldTestCas
 		];
 	}
 
-
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query():string {
+	public function field_query(): string {
 		return '
 			... on MultiSelectField {
 				adminLabel
@@ -214,9 +214,7 @@ class MultiSelectFieldTest extends FormFieldTestCase implements FormFieldTestCas
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
 	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
@@ -246,9 +244,8 @@ class MultiSelectFieldTest extends FormFieldTestCase implements FormFieldTestCas
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ):array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,

--- a/tests/wpunit/NameFieldTest.php
+++ b/tests/wpunit/NameFieldTest.php
@@ -17,28 +17,32 @@ class NameFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -52,7 +56,7 @@ class NameFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [ $this->factory->field->create( $this->property_helper->values ) ];
 	}
 
@@ -104,10 +108,8 @@ class NameFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on NameField {
 				adminLabel
@@ -168,10 +170,8 @@ class NameFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 
 	/**
 	 * SubmitForm mutation string.
-	 *
-	 * @return string
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ($formId: ID!, $fieldId: Int!, $value: NameFieldInput!, $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: {id: $fieldId, nameValues: $value}}) {
@@ -207,8 +207,6 @@ class NameFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 
 	/**
 	 * Returns the UpdateEntry mutation string.
-	 *
-	 * @return string
 	 */
 	public function update_entry_mutation(): string {
 		return '
@@ -240,8 +238,6 @@ class NameFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
-	 *
-	 * @return string
 	 */
 	public function update_draft_entry_mutation(): string {
 		return '
@@ -270,13 +266,11 @@ class NameFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 			}
 		';
 	}
+
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
-	 * @return array
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
 		$expected[] = $this->expected_field_value( 'nameValues', $this->field_value );
 
@@ -304,9 +298,8 @@ class NameFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,

--- a/tests/wpunit/NumberFieldTest.php
+++ b/tests/wpunit/NumberFieldTest.php
@@ -18,28 +18,32 @@ class NumberFieldTest extends FormFieldTestCase implements FormFieldTestCaseInte
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -53,7 +57,7 @@ class NumberFieldTest extends FormFieldTestCase implements FormFieldTestCaseInte
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [ $this->factory->field->create( $this->property_helper->values ) ];
 	}
 
@@ -71,7 +75,6 @@ class NumberFieldTest extends FormFieldTestCase implements FormFieldTestCaseInte
 		return (string) $this->property_helper->dummy->number();
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -81,10 +84,8 @@ class NumberFieldTest extends FormFieldTestCase implements FormFieldTestCaseInte
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on NumberField {
 				adminLabel
@@ -131,7 +132,7 @@ class NumberFieldTest extends FormFieldTestCase implements FormFieldTestCaseInte
 	/**
 	 * SubmitForm mutation string.
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ($formId: ID!, $fieldId: Int!, $value: String!, $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: {id: $fieldId, value: $value}}) {
@@ -162,7 +163,7 @@ class NumberFieldTest extends FormFieldTestCase implements FormFieldTestCaseInte
 	/**
 	 * Returns the UpdateEntry mutation string.
 	 */
-	public function update_entry_mutation() : string {
+	public function update_entry_mutation(): string {
 		return '
 			mutation updateGfEntry( $entryId: ID!, $fieldId: Int!, $value: String! ){
 				updateGfEntry( input: { id: $entryId, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -187,7 +188,7 @@ class NumberFieldTest extends FormFieldTestCase implements FormFieldTestCaseInte
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
 	 */
-	public function update_draft_entry_mutation() : string {
+	public function update_draft_entry_mutation(): string {
 		return '
 			mutation updateGfDraftEntry( $resumeToken: ID!, $fieldId: Int!, $value: String! ){
 				updateGfDraftEntry( input: {id: $resumeToken, idType: RESUME_TOKEN, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -210,11 +211,9 @@ class NumberFieldTest extends FormFieldTestCase implements FormFieldTestCaseInte
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
 		$expected[] = $this->expected_field_value( 'value', $this->field_value );
 
@@ -242,9 +241,8 @@ class NumberFieldTest extends FormFieldTestCase implements FormFieldTestCaseInte
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,
@@ -276,7 +274,7 @@ class NumberFieldTest extends FormFieldTestCase implements FormFieldTestCaseInte
 	 * @param array $actual_entry .
 	 * @param array $form .
 	 */
-	public function check_saved_values( $actual_entry, $form ) : void {
+	public function check_saved_values( $actual_entry, $form ): void {
 		$this->assertEquals( $this->field_value, $actual_entry[ $form['fields'][0]->id ], 'Submit mutation entry value not equal' );
 	}
 }

--- a/tests/wpunit/OptionCheckboxFieldTest.php
+++ b/tests/wpunit/OptionCheckboxFieldTest.php
@@ -20,28 +20,32 @@ class OptionCheckboxFieldTest extends FormFieldTestCase implements FormFieldTest
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -71,7 +75,7 @@ class OptionCheckboxFieldTest extends FormFieldTestCase implements FormFieldTest
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [
 			$this->factory->field->create(
 				array_merge(
@@ -124,10 +128,9 @@ class OptionCheckboxFieldTest extends FormFieldTestCase implements FormFieldTest
 		];
 	}
 
-	public function mutation_value_field_id() : int {
+	public function mutation_value_field_id(): int {
 		return $this->fields[1]->id;
 	}
-
 
 	/**
 	 * The value as expected in GraphQL.
@@ -247,7 +250,6 @@ class OptionCheckboxFieldTest extends FormFieldTestCase implements FormFieldTest
 		];
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -262,10 +264,8 @@ class OptionCheckboxFieldTest extends FormFieldTestCase implements FormFieldTest
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on OptionField {
 				adminLabel
@@ -336,7 +336,7 @@ class OptionCheckboxFieldTest extends FormFieldTestCase implements FormFieldTest
 	/**
 	 * SubmitForm mutation string.
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ($formId: ID!, $fieldId: Int!, $value: [CheckboxFieldInput]!, $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: {id: $fieldId, checkboxValues: $value}}) {
@@ -387,7 +387,7 @@ class OptionCheckboxFieldTest extends FormFieldTestCase implements FormFieldTest
 	/**
 	 * Returns the UpdateEntry mutation string.
 	 */
-	public function update_entry_mutation() : string {
+	public function update_entry_mutation(): string {
 		return '
 			mutation updateGfEntry( $entryId: ID!, $fieldId: Int!, $value: [CheckboxFieldInput]! ){
 				updateGfEntry( input: { id: $entryId, shouldValidate: true, fieldValues: {id: $fieldId, checkboxValues: $value} }) {
@@ -417,7 +417,7 @@ class OptionCheckboxFieldTest extends FormFieldTestCase implements FormFieldTest
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
 	 */
-	public function update_draft_entry_mutation() : string {
+	public function update_draft_entry_mutation(): string {
 		return '
 			mutation updateGfDraftEntry( $resumeToken: ID!, $fieldId: Int!, $value: [CheckboxFieldInput]! ){
 				updateGfDraftEntry( input: {id: $resumeToken, idType: RESUME_TOKEN, shouldValidate: true, fieldValues: {id: $fieldId, checkboxValues: $value} }) {
@@ -444,11 +444,9 @@ class OptionCheckboxFieldTest extends FormFieldTestCase implements FormFieldTest
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][1] );
 		$expected[] = $this->expected_field_value( 'checkboxValues', $this->field_value );
 
@@ -476,9 +474,8 @@ class OptionCheckboxFieldTest extends FormFieldTestCase implements FormFieldTest
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,
@@ -505,7 +502,7 @@ class OptionCheckboxFieldTest extends FormFieldTestCase implements FormFieldTest
 	 * @param array $actual_entry .
 	 * @param array $form .
 	 */
-	public function check_saved_values( $actual_entry, $form ) : void {
+	public function check_saved_values( $actual_entry, $form ): void {
 		$this->assertEquals( $this->field_value[0]['value'], $actual_entry[ $form['fields'][1]['inputs'][0]['id'] ] );
 		$this->assertEquals( $this->field_value[1]['value'], $actual_entry[ $form['fields'][1]['inputs'][1]['id'] ] );
 		$this->assertEquals( $this->field_value[2]['value'], $actual_entry[ $form['fields'][1]['inputs'][2]['id'] ] );

--- a/tests/wpunit/OptionRadioFieldTest.php
+++ b/tests/wpunit/OptionRadioFieldTest.php
@@ -20,28 +20,32 @@ class OptionRadioFieldTest extends FormFieldTestCase implements FormFieldTestCas
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -71,7 +75,7 @@ class OptionRadioFieldTest extends FormFieldTestCase implements FormFieldTestCas
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [
 			$this->factory->field->create(
 				array_merge(
@@ -103,7 +107,7 @@ class OptionRadioFieldTest extends FormFieldTestCase implements FormFieldTestCas
 		];
 	}
 
-	public function mutation_value_field_id() : int {
+	public function mutation_value_field_id(): int {
 		return $this->fields[1]->id;
 	}
 
@@ -143,10 +147,8 @@ class OptionRadioFieldTest extends FormFieldTestCase implements FormFieldTestCas
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on OptionField {
 				adminLabel
@@ -191,7 +193,7 @@ class OptionRadioFieldTest extends FormFieldTestCase implements FormFieldTestCas
 	/**
 	 * SubmitForm mutation string.
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ($formId: ID!, $fieldId: Int!, $value: String!, $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: {id: $fieldId, value: $value}}) {
@@ -222,7 +224,7 @@ class OptionRadioFieldTest extends FormFieldTestCase implements FormFieldTestCas
 	/**
 	 * Returns the UpdateEntry mutation string.
 	 */
-	public function update_entry_mutation() : string {
+	public function update_entry_mutation(): string {
 		return '
 			mutation updateGfEntry( $entryId: ID!, $fieldId: Int!, $value: String! ){
 				updateGfEntry( input: { id: $entryId, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -248,7 +250,7 @@ class OptionRadioFieldTest extends FormFieldTestCase implements FormFieldTestCas
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
 	 */
-	public function update_draft_entry_mutation() : string {
+	public function update_draft_entry_mutation(): string {
 		return '
 			mutation updateGfDraftEntry( $resumeToken: ID!, $fieldId: Int!, $value: String! ){
 				updateGfDraftEntry( input: {id: $resumeToken, idType: RESUME_TOKEN, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -271,11 +273,9 @@ class OptionRadioFieldTest extends FormFieldTestCase implements FormFieldTestCas
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][1] );
 		$expected[] = $this->expected_field_value( 'value', $this->field_value );
 
@@ -303,9 +303,8 @@ class OptionRadioFieldTest extends FormFieldTestCase implements FormFieldTestCas
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,
@@ -332,7 +331,7 @@ class OptionRadioFieldTest extends FormFieldTestCase implements FormFieldTestCas
 	 * @param array $actual_entry .
 	 * @param array $form .
 	 */
-	public function check_saved_values( $actual_entry, $form ) : void {
+	public function check_saved_values( $actual_entry, $form ): void {
 		$this->assertStringStartsWith( $this->field_value_input(), $actual_entry[ $form['fields'][1]->id ], 'Submit mutation entry value not equal' );
 	}
 }

--- a/tests/wpunit/OptionSelectFieldTest.php
+++ b/tests/wpunit/OptionSelectFieldTest.php
@@ -20,28 +20,32 @@ class OptionSelectFieldTest extends FormFieldTestCase implements FormFieldTestCa
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -75,7 +79,7 @@ class OptionSelectFieldTest extends FormFieldTestCase implements FormFieldTestCa
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [
 			$this->factory->field->create(
 				array_merge(
@@ -110,10 +114,9 @@ class OptionSelectFieldTest extends FormFieldTestCase implements FormFieldTestCa
 		];
 	}
 
-	public function mutation_value_field_id() : int {
+	public function mutation_value_field_id(): int {
 		return $this->fields[1]->id;
 	}
-
 
 	/**
 	 * The value as expected in GraphQL.
@@ -151,10 +154,8 @@ class OptionSelectFieldTest extends FormFieldTestCase implements FormFieldTestCa
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on OptionField {
 				adminLabel
@@ -202,7 +203,7 @@ class OptionSelectFieldTest extends FormFieldTestCase implements FormFieldTestCa
 	/**
 	 * SubmitForm mutation string.
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ($formId: ID!, $fieldId: Int!, $value: String!, $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: {id: $fieldId, value: $value}}) {
@@ -233,7 +234,7 @@ class OptionSelectFieldTest extends FormFieldTestCase implements FormFieldTestCa
 	/**
 	 * Returns the UpdateEntry mutation string.
 	 */
-	public function update_entry_mutation() : string {
+	public function update_entry_mutation(): string {
 		return '
 			mutation updateGfEntry( $entryId: ID!, $fieldId: Int!, $value: String! ){
 				updateGfEntry( input: { id: $entryId, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -259,7 +260,7 @@ class OptionSelectFieldTest extends FormFieldTestCase implements FormFieldTestCa
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
 	 */
-	public function update_draft_entry_mutation() : string {
+	public function update_draft_entry_mutation(): string {
 		return '
 			mutation updateGfDraftEntry( $resumeToken: ID!, $fieldId: Int!, $value: String! ){
 				updateGfDraftEntry( input: {id: $resumeToken, idType: RESUME_TOKEN, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -282,11 +283,9 @@ class OptionSelectFieldTest extends FormFieldTestCase implements FormFieldTestCa
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][1] );
 		$expected[] = $this->expected_field_value( 'value', $this->field_value );
 
@@ -314,9 +313,8 @@ class OptionSelectFieldTest extends FormFieldTestCase implements FormFieldTestCa
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,
@@ -343,7 +341,7 @@ class OptionSelectFieldTest extends FormFieldTestCase implements FormFieldTestCa
 	 * @param array $actual_entry .
 	 * @param array $form .
 	 */
-	public function check_saved_values( $actual_entry, $form ) : void {
+	public function check_saved_values( $actual_entry, $form ): void {
 		$this->assertStringStartsWith( $this->field_value_input, $actual_entry[ $form['fields'][1]->id ], 'Submit mutation entry value not equal' );
 	}
 }

--- a/tests/wpunit/PageFieldTest.php
+++ b/tests/wpunit/PageFieldTest.php
@@ -29,7 +29,7 @@ class PageFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [ $this->factory->field->create( $this->property_helper->values ) ];
 	}
 
@@ -45,7 +45,6 @@ class PageFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	public function updated_field_value() {
 		return ''; }
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -54,10 +53,8 @@ class PageFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on PageField {
 				conditionalLogic {
@@ -105,29 +102,27 @@ class PageFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	/**
 	 * SubmitForm mutation string.
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return ''; }
 
 	/**
 	 * Returns the UpdateEntry mutation string.
 	 */
-	public function update_entry_mutation() : string {
+	public function update_entry_mutation(): string {
 		return '';
 	}
 
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
 	 */
-	public function update_draft_entry_mutation() : string {
+	public function update_draft_entry_mutation(): string {
 		return '';
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected = $this->getExpectedFormFieldValues( $form['fields'][0] );
 
 		return [
@@ -154,9 +149,8 @@ class PageFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [];
 	}
 
@@ -166,5 +160,5 @@ class PageFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	 * @param array $actual_entry .
 	 * @param array $form .
 	 */
-	public function check_saved_values( $actual_entry, $form ) : void {}
+	public function check_saved_values( $actual_entry, $form ): void {}
 }

--- a/tests/wpunit/PhoneFieldTest.php
+++ b/tests/wpunit/PhoneFieldTest.php
@@ -18,28 +18,32 @@ class PhoneFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -53,7 +57,7 @@ class PhoneFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [ $this->factory->field->create( $this->property_helper->values ) ];
 	}
 
@@ -71,7 +75,6 @@ class PhoneFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 		return (string) $this->property_helper->dummy->telephone();
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -81,10 +84,8 @@ class PhoneFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on PhoneField {
 				adminLabel
@@ -126,7 +127,7 @@ class PhoneFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 	/**
 	 * SubmitForm mutation string.
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ($formId: ID!, $fieldId: Int!, $value: String!, $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: {id: $fieldId, value: $value}}) {
@@ -157,7 +158,7 @@ class PhoneFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 	/**
 	 * Returns the UpdateEntry mutation string.
 	 */
-	public function update_entry_mutation() : string {
+	public function update_entry_mutation(): string {
 		return '
 			mutation updateGfEntry( $entryId: ID!, $fieldId: Int!, $value: String! ){
 				updateGfEntry( input: { id: $entryId, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -182,7 +183,7 @@ class PhoneFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
 	 */
-	public function update_draft_entry_mutation() : string {
+	public function update_draft_entry_mutation(): string {
 		return '
 			mutation updateGfDraftEntry( $resumeToken: ID!, $fieldId: Int!, $value: String! ){
 				updateGfDraftEntry( input: {id: $resumeToken, idType: RESUME_TOKEN, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -205,11 +206,9 @@ class PhoneFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
 		$expected[] = $this->expected_field_value( 'value', $this->field_value );
 
@@ -237,9 +236,8 @@ class PhoneFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,
@@ -271,7 +269,7 @@ class PhoneFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 	 * @param array $actual_entry .
 	 * @param array $form .
 	 */
-	public function check_saved_values( $actual_entry, $form ) : void {
+	public function check_saved_values( $actual_entry, $form ): void {
 		$this->assertEquals( $this->field_value, $actual_entry[ $form['fields'][0]->id ], 'Submit mutation entry value not equal' );
 	}
 }

--- a/tests/wpunit/PostCategoryCheckboxFieldTest.php
+++ b/tests/wpunit/PostCategoryCheckboxFieldTest.php
@@ -18,14 +18,16 @@ class PostCategoryCheckboxFieldTest extends FormFieldTestCase implements FormFie
 		// Before...
 		$this->cat_id_1 = self::factory()->category->create();
 		$this->cat_id_2 = self::factory()->category->create();
+
 		parent::setUp();
 
 		$this->clearSchema();
 	}
 
-	public function tearDown() : void {
+	public function tearDown(): void {
 		wp_delete_category( $this->cat_id_1 );
 		wp_delete_category( $this->cat_id_2 );
+
 		parent::tearDown();
 	}
 
@@ -35,28 +37,32 @@ class PostCategoryCheckboxFieldTest extends FormFieldTestCase implements FormFie
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -70,7 +76,7 @@ class PostCategoryCheckboxFieldTest extends FormFieldTestCase implements FormFie
 	/**
 	 * Generates the form fields from factory. Must be wrapped in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [
 			$this->factory->field->create(
 				array_merge(
@@ -198,6 +204,7 @@ class PostCategoryCheckboxFieldTest extends FormFieldTestCase implements FormFie
 			],
 		];
 	}
+
 	/**
 	 * The graphql field value input.
 	 */
@@ -239,8 +246,6 @@ class PostCategoryCheckboxFieldTest extends FormFieldTestCase implements FormFie
 		];
 	}
 
-
-
 	/**
 	 * The value as expected in GraphQL when updating from field_value().
 	 */
@@ -280,13 +285,10 @@ class PostCategoryCheckboxFieldTest extends FormFieldTestCase implements FormFie
 		];
 	}
 
-
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query():string {
+	public function field_query(): string {
 		return '... on PostCategoryField {
 				adminLabel
 				canPrepopulate
@@ -466,9 +468,7 @@ class PostCategoryCheckboxFieldTest extends FormFieldTestCase implements FormFie
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
 	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
@@ -498,9 +498,8 @@ class PostCategoryCheckboxFieldTest extends FormFieldTestCase implements FormFie
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ):array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,

--- a/tests/wpunit/PostCategoryMultiSelectFieldTest.php
+++ b/tests/wpunit/PostCategoryMultiSelectFieldTest.php
@@ -19,14 +19,16 @@ class PostCategoryMultiSelectFieldTest extends FormFieldTestCase implements Form
 		// Before...
 		$this->cat_id_1 = self::factory()->category->create();
 		$this->cat_id_2 = self::factory()->category->create();
+
 		parent::setUp();
 
 		$this->clearSchema();
 	}
 
-	public function tearDown() : void {
+	public function tearDown(): void {
 		wp_delete_category( $this->cat_id_1 );
 		wp_delete_category( $this->cat_id_2 );
+
 		parent::tearDown();
 	}
 
@@ -36,28 +38,32 @@ class PostCategoryMultiSelectFieldTest extends FormFieldTestCase implements Form
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -71,7 +77,7 @@ class PostCategoryMultiSelectFieldTest extends FormFieldTestCase implements Form
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 			return [
 				$this->factory->field->create(
 					array_merge(
@@ -120,13 +126,13 @@ class PostCategoryMultiSelectFieldTest extends FormFieldTestCase implements Form
 			$this->fields[0]['choices'][1]['value'],
 		];
 	}
+
 	/**
 	 * The graphql field value input.
 	 */
 	public function updated_field_value_input() {
 		return [ $this->fields[0]['choices'][2]['value'] ];
 	}
-
 
 	/**
 	 * The value as expected in GraphQL when updating from field_value().
@@ -146,13 +152,10 @@ class PostCategoryMultiSelectFieldTest extends FormFieldTestCase implements Form
 		];
 	}
 
-
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query():string {
+	public function field_query(): string {
 		return '
 			... on PostCategoryField {
 				adminLabel
@@ -281,9 +284,7 @@ class PostCategoryMultiSelectFieldTest extends FormFieldTestCase implements Form
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
 	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
@@ -313,9 +314,8 @@ class PostCategoryMultiSelectFieldTest extends FormFieldTestCase implements Form
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ):array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,

--- a/tests/wpunit/PostCategoryRadioFieldTest.php
+++ b/tests/wpunit/PostCategoryRadioFieldTest.php
@@ -18,14 +18,16 @@ class PostCategoryFieldRadioTest extends FormFieldTestCase implements FormFieldT
 		// Before...
 		$this->cat_id_1 = self::factory()->category->create();
 		$this->cat_id_2 = self::factory()->category->create();
+
 		parent::setUp();
 
 		$this->clearSchema();
 	}
 
-	public function tearDown() : void {
+	public function tearDown(): void {
 		wp_delete_category( $this->cat_id_1 );
 		wp_delete_category( $this->cat_id_2 );
+
 		parent::tearDown();
 	}
 
@@ -35,28 +37,32 @@ class PostCategoryFieldRadioTest extends FormFieldTestCase implements FormFieldT
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -70,7 +76,7 @@ class PostCategoryFieldRadioTest extends FormFieldTestCase implements FormFieldT
 	/**
 	 * Generates the form fields from factory. Must be wrapped in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [
 			$this->factory->field->create(
 				array_merge(
@@ -113,6 +119,7 @@ class PostCategoryFieldRadioTest extends FormFieldTestCase implements FormFieldT
 	public function field_value_input() {
 		return $this->fields[0]['choices'][0]['value'];
 	}
+
 	/**
 	 * The graphql field value input.
 	 */
@@ -127,7 +134,6 @@ class PostCategoryFieldRadioTest extends FormFieldTestCase implements FormFieldT
 		return $this->fields[0]['choices'][2]['text'] . ':' . $this->fields[0]['choices'][2]['value'];
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -135,13 +141,10 @@ class PostCategoryFieldRadioTest extends FormFieldTestCase implements FormFieldT
 		return [ (string) $this->fields[0]['id'] => $this->field_value_input ];
 	}
 
-
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query():string {
+	public function field_query(): string {
 		return '... on PostCategoryField {
 				adminLabel
 				canPrepopulate
@@ -271,9 +274,7 @@ class PostCategoryFieldRadioTest extends FormFieldTestCase implements FormFieldT
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
 	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
@@ -303,9 +304,8 @@ class PostCategoryFieldRadioTest extends FormFieldTestCase implements FormFieldT
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ):array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,

--- a/tests/wpunit/PostCategorySelectFieldTest.php
+++ b/tests/wpunit/PostCategorySelectFieldTest.php
@@ -18,14 +18,16 @@ class PostCategoryFieldSelectTest extends FormFieldTestCase implements FormField
 		// Before...
 		$this->cat_id_1 = self::factory()->category->create();
 		$this->cat_id_2 = self::factory()->category->create();
+
 		parent::setUp();
 
 		$this->clearSchema();
 	}
 
-	public function tearDown() : void {
+	public function tearDown(): void {
 		wp_delete_category( $this->cat_id_1 );
 		wp_delete_category( $this->cat_id_2 );
+
 		parent::tearDown();
 	}
 
@@ -35,28 +37,32 @@ class PostCategoryFieldSelectTest extends FormFieldTestCase implements FormField
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -70,7 +76,7 @@ class PostCategoryFieldSelectTest extends FormFieldTestCase implements FormField
 	/**
 	 * Generates the form fields from factory. Must be wrapped in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [
 			$this->factory->field->create(
 				array_merge(
@@ -113,6 +119,7 @@ class PostCategoryFieldSelectTest extends FormFieldTestCase implements FormField
 	public function field_value_input() {
 		return $this->fields[0]['choices'][0]['value'];
 	}
+
 	/**
 	 * The graphql field value input.
 	 */
@@ -127,7 +134,6 @@ class PostCategoryFieldSelectTest extends FormFieldTestCase implements FormField
 		return $this->fields[0]['choices'][2]['text'] . ':' . $this->fields[0]['choices'][2]['value'];
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -135,13 +141,10 @@ class PostCategoryFieldSelectTest extends FormFieldTestCase implements FormField
 		return [ (string) $this->fields[0]['id'] => $this->field_value_input ];
 	}
 
-
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query():string {
+	public function field_query(): string {
 		return '... on PostCategoryField {
 				adminLabel
 				canPrepopulate
@@ -274,9 +277,7 @@ class PostCategoryFieldSelectTest extends FormFieldTestCase implements FormField
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
 	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
@@ -306,9 +307,8 @@ class PostCategoryFieldSelectTest extends FormFieldTestCase implements FormField
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ):array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,

--- a/tests/wpunit/PostContentFieldTest.php
+++ b/tests/wpunit/PostContentFieldTest.php
@@ -12,37 +12,42 @@ use Tests\WPGraphQL\GF\TestCase\FormFieldTestCaseInterface;
 /**
  * Class -PostContentFieldTest.
  */
-class PostContentFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInterface {
+class PostContentFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterface {
 	/**
 	 * Tests the field properties and values.
 	 */
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
+
 	/**
 	 * Sets the correct Field Helper.
 	 */
@@ -53,7 +58,7 @@ class PostContentFieldTest  extends FormFieldTestCase implements FormFieldTestCa
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [ $this->factory->field->create( $this->property_helper->values ) ];
 	}
 
@@ -71,7 +76,6 @@ class PostContentFieldTest  extends FormFieldTestCase implements FormFieldTestCa
 		return $this->property_helper->dummy->words( 1, 5 );
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -81,10 +85,8 @@ class PostContentFieldTest  extends FormFieldTestCase implements FormFieldTestCa
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on PostContentField {
 				adminLabel
@@ -124,7 +126,7 @@ class PostContentFieldTest  extends FormFieldTestCase implements FormFieldTestCa
 	/**
 	 * SubmitForm mutation string.
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ($formId: ID!, $fieldId: Int!, $value: String!, $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: {id: $fieldId, value: $value}}) {
@@ -155,7 +157,7 @@ class PostContentFieldTest  extends FormFieldTestCase implements FormFieldTestCa
 	/**
 	 * Returns the UpdateEntry mutation string.
 	 */
-	public function update_entry_mutation() : string {
+	public function update_entry_mutation(): string {
 		return '
 			mutation updateGfEntry( $entryId: ID!, $fieldId: Int!, $value: String! ){
 				updateGfEntry( input: { id: $entryId, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -180,7 +182,7 @@ class PostContentFieldTest  extends FormFieldTestCase implements FormFieldTestCa
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
 	 */
-	public function update_draft_entry_mutation() : string {
+	public function update_draft_entry_mutation(): string {
 		return '
 			mutation updateGfDraftEntry( $resumeToken: ID!, $fieldId: Int!, $value: String! ){
 				updateGfDraftEntry( input: {id: $resumeToken, idType: RESUME_TOKEN, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -203,11 +205,9 @@ class PostContentFieldTest  extends FormFieldTestCase implements FormFieldTestCa
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
 		$expected[] = $this->expected_field_value( 'value', $this->field_value );
 
@@ -235,9 +235,8 @@ class PostContentFieldTest  extends FormFieldTestCase implements FormFieldTestCa
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,
@@ -269,7 +268,7 @@ class PostContentFieldTest  extends FormFieldTestCase implements FormFieldTestCa
 	 * @param array $actual_entry .
 	 * @param array $form .
 	 */
-	public function check_saved_values( $actual_entry, $form ) : void {
+	public function check_saved_values( $actual_entry, $form ): void {
 		$this->assertEquals( $this->field_value, $actual_entry[ $form['fields'][0]->id ], 'Submit mutation entry value not equal' );
 	}
 }

--- a/tests/wpunit/PostExcerptFieldTest.php
+++ b/tests/wpunit/PostExcerptFieldTest.php
@@ -12,37 +12,42 @@ use Tests\WPGraphQL\GF\TestCase\FormFieldTestCaseInterface;
 /**
  * Class -PostExcerptFieldTest.
  */
-class PostExcerptFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInterface {
+class PostExcerptFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterface {
 	/**
 	 * Tests the field properties and values.
 	 */
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
+
 	/**
 	 * Sets the correct Field Helper.
 	 */
@@ -53,7 +58,7 @@ class PostExcerptFieldTest  extends FormFieldTestCase implements FormFieldTestCa
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [ $this->factory->field->create( $this->property_helper->values ) ];
 	}
 
@@ -71,7 +76,6 @@ class PostExcerptFieldTest  extends FormFieldTestCase implements FormFieldTestCa
 		return $this->property_helper->dummy->words( 1, 5 );
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -81,10 +85,8 @@ class PostExcerptFieldTest  extends FormFieldTestCase implements FormFieldTestCa
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '... on PostExcerptField {
 				adminLabel
 				canPrepopulate
@@ -122,7 +124,7 @@ class PostExcerptFieldTest  extends FormFieldTestCase implements FormFieldTestCa
 	/**
 	 * SubmitForm mutation string.
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ($formId: ID!, $fieldId: Int!, $value: String!, $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: {id: $fieldId, value: $value}}) {
@@ -153,7 +155,7 @@ class PostExcerptFieldTest  extends FormFieldTestCase implements FormFieldTestCa
 	/**
 	 * Returns the UpdateEntry mutation string.
 	 */
-	public function update_entry_mutation() : string {
+	public function update_entry_mutation(): string {
 		return '
 			mutation updateGfEntry( $entryId: ID!, $fieldId: Int!, $value: String! ){
 				updateGfEntry( input: { id: $entryId, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -178,7 +180,7 @@ class PostExcerptFieldTest  extends FormFieldTestCase implements FormFieldTestCa
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
 	 */
-	public function update_draft_entry_mutation() : string {
+	public function update_draft_entry_mutation(): string {
 		return '
 			mutation updateGfDraftEntry( $resumeToken: ID!, $fieldId: Int!, $value: String! ){
 				updateGfDraftEntry( input: {id: $resumeToken, idType: RESUME_TOKEN, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -201,11 +203,9 @@ class PostExcerptFieldTest  extends FormFieldTestCase implements FormFieldTestCa
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
 		$expected[] = $this->expected_field_value( 'value', $this->field_value );
 
@@ -233,9 +233,8 @@ class PostExcerptFieldTest  extends FormFieldTestCase implements FormFieldTestCa
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,
@@ -267,7 +266,7 @@ class PostExcerptFieldTest  extends FormFieldTestCase implements FormFieldTestCa
 	 * @param array $actual_entry .
 	 * @param array $form .
 	 */
-	public function check_saved_values( $actual_entry, $form ) : void {
+	public function check_saved_values( $actual_entry, $form ): void {
 		$this->assertEquals( $this->field_value, $actual_entry[ $form['fields'][0]->id ], 'Submit mutation entry value not equal' );
 	}
 }

--- a/tests/wpunit/PostImageFieldTest.php
+++ b/tests/wpunit/PostImageFieldTest.php
@@ -46,11 +46,11 @@ class PostImageFieldTest extends FormFieldTestCase implements FormFieldTestCaseI
 	public function setUp(): void {
 
 		// Before...
-		copy( dirname( __FILE__ ) . '/../_support/files/img1.png', '/tmp/img1.png' );
+		copy( __DIR__ . '/../_support/files/img1.png', '/tmp/img1.png' );
 		$stat  = stat( dirname( '/tmp/img1.png' ) );
 		$perms = $stat['mode'] & 0000666;
 		chmod( '/tmp/img1.png', $perms );
-		copy( dirname( __FILE__ ) . '/../_support/files/img2.png', '/tmp/img2.png' );
+		copy( __DIR__ . '/../_support/files/img2.png', '/tmp/img2.png' );
 		$stat  = stat( dirname( '/tmp/img2.png' ) );
 		$perms = $stat['mode'] & 0000666;
 		chmod( '/tmp/img2.png', $perms );
@@ -73,34 +73,39 @@ class PostImageFieldTest extends FormFieldTestCase implements FormFieldTestCaseI
 
 		parent::tearDown();
 	}
+
 	/**
 	 * Tests the field properties and values.
 	 */
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -114,7 +119,7 @@ class PostImageFieldTest extends FormFieldTestCase implements FormFieldTestCaseI
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [ $this->factory->field->create( $this->property_helper->values ) ];
 	}
 
@@ -210,10 +215,8 @@ class PostImageFieldTest extends FormFieldTestCase implements FormFieldTestCaseI
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on PostImageField {
 				adminLabel
@@ -260,10 +263,8 @@ class PostImageFieldTest extends FormFieldTestCase implements FormFieldTestCaseI
 
 	/**
 	 * SubmitForm mutation string.
-	 *
-	 * @return string
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ($formId: ID!, $fieldId: Int!, $value: ImageInput!, $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: {id: $fieldId, imageValues: $value}}) {
@@ -300,8 +301,6 @@ class PostImageFieldTest extends FormFieldTestCase implements FormFieldTestCaseI
 
 	/**
 	 * Returns the UpdateEntry mutation string.
-	 *
-	 * @return string
 	 */
 	public function update_entry_mutation(): string {
 		return '
@@ -334,8 +333,6 @@ class PostImageFieldTest extends FormFieldTestCase implements FormFieldTestCaseI
 
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
-	 *
-	 * @return string
 	 */
 	public function update_draft_entry_mutation(): string {
 		return '
@@ -365,13 +362,11 @@ class PostImageFieldTest extends FormFieldTestCase implements FormFieldTestCaseI
 			}
 		';
 	}
+
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
-	 * @return array
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected = $this->getExpectedFormFieldValues( $form['fields'][0] );
 
 		$value = $this->is_draft ? $this->draft_field_value : $this->field_value;
@@ -405,9 +400,8 @@ class PostImageFieldTest extends FormFieldTestCase implements FormFieldTestCaseI
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		if ( empty( $value['url'] ) || $this->is_draft ) {
 			unset( $value['url'] );
 		}

--- a/tests/wpunit/PostTagsCheckboxFieldTest.php
+++ b/tests/wpunit/PostTagsCheckboxFieldTest.php
@@ -20,15 +20,17 @@ class PostTagsCheckboxFieldTest extends FormFieldTestCase implements FormFieldTe
 		$this->tag_id_1 = self::factory()->tag->create();
 		$this->tag_id_2 = self::factory()->tag->create();
 		$this->tag_id_3 = self::factory()->tag->create();
+
 		parent::setUp();
 
 		$this->clearSchema();
 	}
 
-	public function tearDown() : void {
+	public function tearDown(): void {
 		wp_delete_term( $this->tag_id_1, 'post_tag' );
 		wp_delete_term( $this->tag_id_2, 'post_tag' );
 		wp_delete_term( $this->tag_id_3, 'post_tag' );
+
 		parent::tearDown();
 	}
 
@@ -38,28 +40,32 @@ class PostTagsCheckboxFieldTest extends FormFieldTestCase implements FormFieldTe
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -73,7 +79,7 @@ class PostTagsCheckboxFieldTest extends FormFieldTestCase implements FormFieldTe
 	/**
 	 * Generates the form fields from factory. Must be wrapped in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [
 			$this->factory->field->create(
 				array_merge(
@@ -165,6 +171,7 @@ class PostTagsCheckboxFieldTest extends FormFieldTestCase implements FormFieldTe
 			],
 		];
 	}
+
 	/**
 	 * The graphql field value input.
 	 */
@@ -185,8 +192,6 @@ class PostTagsCheckboxFieldTest extends FormFieldTestCase implements FormFieldTe
 			],
 		];
 	}
-
-
 
 	/**
 	 * The value as expected in GraphQL when updating from field_value().
@@ -221,13 +226,10 @@ class PostTagsCheckboxFieldTest extends FormFieldTestCase implements FormFieldTe
 		];
 	}
 
-
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query():string {
+	public function field_query(): string {
 		return '... on PostTagsField {
 				adminLabel
 				canPrepopulate
@@ -378,9 +380,7 @@ class PostTagsCheckboxFieldTest extends FormFieldTestCase implements FormFieldTe
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
 	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
@@ -410,9 +410,8 @@ class PostTagsCheckboxFieldTest extends FormFieldTestCase implements FormFieldTe
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ):array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,

--- a/tests/wpunit/PostTagsMultiSelectFieldTest.php
+++ b/tests/wpunit/PostTagsMultiSelectFieldTest.php
@@ -21,15 +21,17 @@ class PostTagsMultiSelectFieldTest extends FormFieldTestCase implements FormFiel
 		$this->tag_id_1 = self::factory()->tag->create();
 		$this->tag_id_2 = self::factory()->tag->create();
 		$this->tag_id_3 = self::factory()->tag->create();
+
 		parent::setUp();
 
 		$this->clearSchema();
 	}
 
-	public function tearDown() : void {
+	public function tearDown(): void {
 		wp_delete_term( $this->tag_id_1, 'post_tag' );
 		wp_delete_term( $this->tag_id_2, 'post_tag' );
 		wp_delete_term( $this->tag_id_3, 'post_tag' );
+
 		parent::tearDown();
 	}
 
@@ -39,28 +41,32 @@ class PostTagsMultiSelectFieldTest extends FormFieldTestCase implements FormFiel
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -74,7 +80,7 @@ class PostTagsMultiSelectFieldTest extends FormFieldTestCase implements FormFiel
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 			return [
 				$this->factory->field->create(
 					array_merge(
@@ -123,13 +129,13 @@ class PostTagsMultiSelectFieldTest extends FormFieldTestCase implements FormFiel
 			$this->fields[0]['choices'][1]['value'],
 		];
 	}
+
 	/**
 	 * The graphql field value input.
 	 */
 	public function updated_field_value_input() {
 		return [ $this->fields[0]['choices'][2]['value'] ];
 	}
-
 
 	/**
 	 * The value as expected in GraphQL when updating from field_value().
@@ -149,13 +155,10 @@ class PostTagsMultiSelectFieldTest extends FormFieldTestCase implements FormFiel
 		];
 	}
 
-
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query():string {
+	public function field_query(): string {
 		return '
 			... on PostTagsField {
 				adminLabel
@@ -283,9 +286,7 @@ class PostTagsMultiSelectFieldTest extends FormFieldTestCase implements FormFiel
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
 	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
@@ -315,9 +316,8 @@ class PostTagsMultiSelectFieldTest extends FormFieldTestCase implements FormFiel
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ):array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,

--- a/tests/wpunit/PostTagsRadioFieldTest.php
+++ b/tests/wpunit/PostTagsRadioFieldTest.php
@@ -20,15 +20,17 @@ class PostTagsFieldRadioTest extends FormFieldTestCase implements FormFieldTestC
 		$this->tag_id_1 = self::factory()->tag->create();
 		$this->tag_id_2 = self::factory()->tag->create();
 		$this->tag_id_3 = self::factory()->tag->create();
+
 		parent::setUp();
 
 		$this->clearSchema();
 	}
 
-	public function tearDown() : void {
+	public function tearDown(): void {
 		wp_delete_term( $this->tag_id_1, 'post_tag' );
 		wp_delete_term( $this->tag_id_2, 'post_tag' );
 		wp_delete_term( $this->tag_id_3, 'post_tag' );
+
 		parent::tearDown();
 	}
 
@@ -38,28 +40,32 @@ class PostTagsFieldRadioTest extends FormFieldTestCase implements FormFieldTestC
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -73,7 +79,7 @@ class PostTagsFieldRadioTest extends FormFieldTestCase implements FormFieldTestC
 	/**
 	 * Generates the form fields from factory. Must be wrapped in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [
 			$this->factory->field->create(
 				array_merge(
@@ -116,6 +122,7 @@ class PostTagsFieldRadioTest extends FormFieldTestCase implements FormFieldTestC
 	public function field_value_input() {
 		return $this->fields[0]['choices'][0]['value'];
 	}
+
 	/**
 	 * The graphql field value input.
 	 */
@@ -130,7 +137,6 @@ class PostTagsFieldRadioTest extends FormFieldTestCase implements FormFieldTestC
 		return $this->fields[0]['choices'][2]['value'];
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -138,13 +144,10 @@ class PostTagsFieldRadioTest extends FormFieldTestCase implements FormFieldTestC
 		return [ (string) $this->fields[0]['id'] => $this->field_value_input ];
 	}
 
-
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query():string {
+	public function field_query(): string {
 		return '... on PostTagsField {
 				adminLabel
 				canPrepopulate
@@ -273,9 +276,7 @@ class PostTagsFieldRadioTest extends FormFieldTestCase implements FormFieldTestC
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
 	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
@@ -305,9 +306,8 @@ class PostTagsFieldRadioTest extends FormFieldTestCase implements FormFieldTestC
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ):array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,

--- a/tests/wpunit/PostTagsTextFieldTest.php
+++ b/tests/wpunit/PostTagsTextFieldTest.php
@@ -20,15 +20,17 @@ class PostTagsTextFieldTest extends FormFieldTestCase implements FormFieldTestCa
 		$this->tag_id_1 = self::factory()->tag->create();
 		$this->tag_id_2 = self::factory()->tag->create();
 		$this->tag_id_3 = self::factory()->tag->create();
+
 		parent::setUp();
 
 		$this->clearSchema();
 	}
 
-	public function tearDown() : void {
+	public function tearDown(): void {
 		wp_delete_term( $this->tag_id_1, 'post_tag' );
 		wp_delete_term( $this->tag_id_2, 'post_tag' );
 		wp_delete_term( $this->tag_id_3, 'post_tag' );
+
 		parent::tearDown();
 	}
 
@@ -38,28 +40,32 @@ class PostTagsTextFieldTest extends FormFieldTestCase implements FormFieldTestCa
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -73,7 +79,7 @@ class PostTagsTextFieldTest extends FormFieldTestCase implements FormFieldTestCa
 	/**
 	 * Generates the form fields from factory. Must be wrapped in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [
 			$this->factory->field->create(
 				array_merge(
@@ -105,13 +111,10 @@ class PostTagsTextFieldTest extends FormFieldTestCase implements FormFieldTestCa
 		return [ (string) $this->fields[0]['id'] => $this->field_value_input ];
 	}
 
-
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query():string {
+	public function field_query(): string {
 		return '... on PostTagsField {
 				adminLabel
 				canPrepopulate
@@ -237,9 +240,7 @@ class PostTagsTextFieldTest extends FormFieldTestCase implements FormFieldTestCa
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
 	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
@@ -269,9 +270,8 @@ class PostTagsTextFieldTest extends FormFieldTestCase implements FormFieldTestCa
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ):array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,

--- a/tests/wpunit/PostTitleFieldTest.php
+++ b/tests/wpunit/PostTitleFieldTest.php
@@ -12,37 +12,42 @@ use Tests\WPGraphQL\GF\TestCase\FormFieldTestCaseInterface;
 /**
  * Class -PostTitleFieldTest.
  */
-class PostTitleFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInterface {
+class PostTitleFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterface {
 	/**
 	 * Tests the field properties and values.
 	 */
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
+
 	/**
 	 * Sets the correct Field Helper.
 	 */
@@ -53,7 +58,7 @@ class PostTitleFieldTest  extends FormFieldTestCase implements FormFieldTestCase
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [ $this->factory->field->create( $this->property_helper->values ) ];
 	}
 
@@ -71,7 +76,6 @@ class PostTitleFieldTest  extends FormFieldTestCase implements FormFieldTestCase
 		return $this->property_helper->dummy->words( 1, 5 );
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -81,10 +85,8 @@ class PostTitleFieldTest  extends FormFieldTestCase implements FormFieldTestCase
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on PostTitleField {
 				adminLabel
@@ -122,7 +124,7 @@ class PostTitleFieldTest  extends FormFieldTestCase implements FormFieldTestCase
 	/**
 	 * SubmitForm mutation string.
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ($formId: ID!, $fieldId: Int!, $value: String!, $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: {id: $fieldId, value: $value}}) {
@@ -153,7 +155,7 @@ class PostTitleFieldTest  extends FormFieldTestCase implements FormFieldTestCase
 	/**
 	 * Returns the UpdateEntry mutation string.
 	 */
-	public function update_entry_mutation() : string {
+	public function update_entry_mutation(): string {
 		return '
 			mutation updateGfEntry( $entryId: ID!, $fieldId: Int!, $value: String! ){
 				updateGfEntry( input: { id: $entryId, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -178,7 +180,7 @@ class PostTitleFieldTest  extends FormFieldTestCase implements FormFieldTestCase
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
 	 */
-	public function update_draft_entry_mutation() : string {
+	public function update_draft_entry_mutation(): string {
 		return '
 			mutation updateGfDraftEntry( $resumeToken: ID!, $fieldId: Int!, $value: String! ){
 				updateGfDraftEntry( input: {id: $resumeToken, idType: RESUME_TOKEN, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -201,11 +203,9 @@ class PostTitleFieldTest  extends FormFieldTestCase implements FormFieldTestCase
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
 		$expected[] = $this->expected_field_value( 'value', $this->field_value );
 
@@ -233,9 +233,8 @@ class PostTitleFieldTest  extends FormFieldTestCase implements FormFieldTestCase
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,
@@ -267,7 +266,7 @@ class PostTitleFieldTest  extends FormFieldTestCase implements FormFieldTestCase
 	 * @param array $actual_entry .
 	 * @param array $form .
 	 */
-	public function check_saved_values( $actual_entry, $form ) : void {
+	public function check_saved_values( $actual_entry, $form ): void {
 		$this->assertEquals( $this->field_value, $actual_entry[ $form['fields'][0]->id ], 'Submit mutation entry value not equal' );
 	}
 }

--- a/tests/wpunit/ProductCalculationFieldTest.php
+++ b/tests/wpunit/ProductCalculationFieldTest.php
@@ -17,28 +17,32 @@ class ProductCalculationFieldTest extends FormFieldTestCase implements FormField
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -52,7 +56,7 @@ class ProductCalculationFieldTest extends FormFieldTestCase implements FormField
 	/**
 	 * Generates the form fields from factory. Must be wrapped in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		$label = $this->property_helper->dummy->words( 2 );
 		return [
 			$this->factory->field->create(
@@ -131,7 +135,6 @@ class ProductCalculationFieldTest extends FormFieldTestCase implements FormField
 		];
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -143,13 +146,10 @@ class ProductCalculationFieldTest extends FormFieldTestCase implements FormField
 		];
 	}
 
-
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query():string {
+	public function field_query(): string {
 		return '... on ProductField {
 				adminLabel
 				canPrepopulate
@@ -278,9 +278,7 @@ class ProductCalculationFieldTest extends FormFieldTestCase implements FormField
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
 	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
@@ -310,9 +308,8 @@ class ProductCalculationFieldTest extends FormFieldTestCase implements FormField
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ):array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,

--- a/tests/wpunit/ProductHiddenFieldTest.php
+++ b/tests/wpunit/ProductHiddenFieldTest.php
@@ -17,28 +17,32 @@ class ProductHiddenFieldTest extends FormFieldTestCase implements FormFieldTestC
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -52,7 +56,7 @@ class ProductHiddenFieldTest extends FormFieldTestCase implements FormFieldTestC
 	/**
 	 * Generates the form fields from factory. Must be wrapped in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [
 			$this->factory->field->create(
 				array_merge(
@@ -118,7 +122,6 @@ class ProductHiddenFieldTest extends FormFieldTestCase implements FormFieldTestC
 		];
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -130,13 +133,10 @@ class ProductHiddenFieldTest extends FormFieldTestCase implements FormFieldTestC
 		];
 	}
 
-
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query():string {
+	public function field_query(): string {
 		return '... on ProductField {
 				adminLabel
 				canPrepopulate
@@ -261,9 +261,7 @@ class ProductHiddenFieldTest extends FormFieldTestCase implements FormFieldTestC
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
 	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
@@ -293,9 +291,8 @@ class ProductHiddenFieldTest extends FormFieldTestCase implements FormFieldTestC
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ):array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,

--- a/tests/wpunit/ProductPriceFieldTest.php
+++ b/tests/wpunit/ProductPriceFieldTest.php
@@ -17,28 +17,32 @@ class ProductPriceFieldTest extends FormFieldTestCase implements FormFieldTestCa
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -52,7 +56,7 @@ class ProductPriceFieldTest extends FormFieldTestCase implements FormFieldTestCa
 	/**
 	 * Generates the form fields from factory. Must be wrapped in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [
 			$this->factory->field->create(
 				array_merge(
@@ -100,7 +104,6 @@ class ProductPriceFieldTest extends FormFieldTestCase implements FormFieldTestCa
 		];
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -108,13 +111,10 @@ class ProductPriceFieldTest extends FormFieldTestCase implements FormFieldTestCa
 		return [ $this->fields[0]['id'] => $this->field_value_input ];
 	}
 
-
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query():string {
+	public function field_query(): string {
 		return '... on ProductField {
 				adminLabel
 				canPrepopulate
@@ -242,9 +242,7 @@ class ProductPriceFieldTest extends FormFieldTestCase implements FormFieldTestCa
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
 	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
@@ -274,9 +272,8 @@ class ProductPriceFieldTest extends FormFieldTestCase implements FormFieldTestCa
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ):array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,

--- a/tests/wpunit/ProductRadioFieldTest.php
+++ b/tests/wpunit/ProductRadioFieldTest.php
@@ -17,28 +17,32 @@ class ProductRadioFieldTest extends FormFieldTestCase implements FormFieldTestCa
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -52,7 +56,7 @@ class ProductRadioFieldTest extends FormFieldTestCase implements FormFieldTestCa
 	/**
 	 * Generates the form fields from factory. Must be wrapped in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [
 			$this->factory->field->create(
 				array_merge(
@@ -124,7 +128,6 @@ class ProductRadioFieldTest extends FormFieldTestCase implements FormFieldTestCa
 		];
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -132,13 +135,10 @@ class ProductRadioFieldTest extends FormFieldTestCase implements FormFieldTestCa
 		return [ (string) $this->fields[0]['id'] => $this->fields[0]->choices[0]['value'] . '|5' ];
 	}
 
-
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query():string {
+	public function field_query(): string {
 		return '... on ProductField {
 				adminLabel
 				canPrepopulate
@@ -276,9 +276,7 @@ class ProductRadioFieldTest extends FormFieldTestCase implements FormFieldTestCa
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
 	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
@@ -308,9 +306,8 @@ class ProductRadioFieldTest extends FormFieldTestCase implements FormFieldTestCa
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ):array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,

--- a/tests/wpunit/ProductSelectFieldTest.php
+++ b/tests/wpunit/ProductSelectFieldTest.php
@@ -17,28 +17,32 @@ class ProductSelectFieldTest extends FormFieldTestCase implements FormFieldTestC
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -52,7 +56,7 @@ class ProductSelectFieldTest extends FormFieldTestCase implements FormFieldTestC
 	/**
 	 * Generates the form fields from factory. Must be wrapped in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [
 			$this->factory->field->create(
 				array_merge(
@@ -126,7 +130,6 @@ class ProductSelectFieldTest extends FormFieldTestCase implements FormFieldTestC
 		];
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -134,13 +137,10 @@ class ProductSelectFieldTest extends FormFieldTestCase implements FormFieldTestC
 		return [ (string) $this->fields[0]['id'] => $this->fields[0]->choices[0]['value'] . '|5' ];
 	}
 
-
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query():string {
+	public function field_query(): string {
 		return '... on ProductField {
 				adminLabel
 				canPrepopulate
@@ -281,9 +281,7 @@ class ProductSelectFieldTest extends FormFieldTestCase implements FormFieldTestC
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
 	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
@@ -313,9 +311,8 @@ class ProductSelectFieldTest extends FormFieldTestCase implements FormFieldTestC
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ):array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,

--- a/tests/wpunit/ProductSingleFieldTest.php
+++ b/tests/wpunit/ProductSingleFieldTest.php
@@ -17,28 +17,32 @@ class ProductSingleFieldTest extends FormFieldTestCase implements FormFieldTestC
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -52,7 +56,7 @@ class ProductSingleFieldTest extends FormFieldTestCase implements FormFieldTestC
 	/**
 	 * Generates the form fields from factory. Must be wrapped in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [
 			$this->factory->field->create(
 				array_merge(
@@ -119,7 +123,6 @@ class ProductSingleFieldTest extends FormFieldTestCase implements FormFieldTestC
 		];
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -131,13 +134,10 @@ class ProductSingleFieldTest extends FormFieldTestCase implements FormFieldTestC
 		];
 	}
 
-
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query():string {
+	public function field_query(): string {
 		return '... on ProductField {
 				adminLabel
 				canPrepopulate
@@ -273,9 +273,7 @@ class ProductSingleFieldTest extends FormFieldTestCase implements FormFieldTestC
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
 	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
@@ -305,9 +303,8 @@ class ProductSingleFieldTest extends FormFieldTestCase implements FormFieldTestC
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ):array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,

--- a/tests/wpunit/QuantityHiddenFieldTest.php
+++ b/tests/wpunit/QuantityHiddenFieldTest.php
@@ -20,28 +20,32 @@ class QuantityHiddenFieldTest extends FormFieldTestCase implements FormFieldTest
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -71,7 +75,7 @@ class QuantityHiddenFieldTest extends FormFieldTestCase implements FormFieldTest
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [
 			$this->factory->field->create(
 				array_merge(
@@ -101,10 +105,9 @@ class QuantityHiddenFieldTest extends FormFieldTestCase implements FormFieldTest
 		];
 	}
 
-	public function mutation_value_field_id() : int {
+	public function mutation_value_field_id(): int {
 		return $this->fields[1]->id;
 	}
-
 
 	/**
 	 * The value as expected in GraphQL.
@@ -128,7 +131,6 @@ class QuantityHiddenFieldTest extends FormFieldTestCase implements FormFieldTest
 		return $this->updated_field_value;
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -142,10 +144,8 @@ class QuantityHiddenFieldTest extends FormFieldTestCase implements FormFieldTest
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on QuantityField {
 				adminLabel
@@ -176,7 +176,7 @@ class QuantityHiddenFieldTest extends FormFieldTestCase implements FormFieldTest
 	/**
 	 * SubmitForm mutation string.
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ($formId: ID!, $fieldId: Int!, $value: String!, $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: {id: $fieldId, value: $value}}) {
@@ -207,7 +207,7 @@ class QuantityHiddenFieldTest extends FormFieldTestCase implements FormFieldTest
 	/**
 	 * Returns the UpdateEntry mutation string.
 	 */
-	public function update_entry_mutation() : string {
+	public function update_entry_mutation(): string {
 		return '
 			mutation updateGfEntry( $entryId: ID!, $fieldId: Int!, $value: String! ){
 				updateGfEntry( input: { id: $entryId, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -233,7 +233,7 @@ class QuantityHiddenFieldTest extends FormFieldTestCase implements FormFieldTest
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
 	 */
-	public function update_draft_entry_mutation() : string {
+	public function update_draft_entry_mutation(): string {
 		return '
 			mutation updateGfDraftEntry( $resumeToken: ID!, $fieldId: Int!, $value: String! ){
 				updateGfDraftEntry( input: {id: $resumeToken, idType: RESUME_TOKEN, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -256,11 +256,9 @@ class QuantityHiddenFieldTest extends FormFieldTestCase implements FormFieldTest
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][1] );
 		$expected[] = $this->expected_field_value( 'value', $this->field_value );
 
@@ -288,9 +286,8 @@ class QuantityHiddenFieldTest extends FormFieldTestCase implements FormFieldTest
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,
@@ -317,7 +314,7 @@ class QuantityHiddenFieldTest extends FormFieldTestCase implements FormFieldTest
 	 * @param array $actual_entry .
 	 * @param array $form .
 	 */
-	public function check_saved_values( $actual_entry, $form ) : void {
+	public function check_saved_values( $actual_entry, $form ): void {
 		$this->assertEquals( $this->field_value, $actual_entry[ $form['fields'][1]->id ], 'Submit mutation entry value not equal' );
 	}
 }

--- a/tests/wpunit/QuantityNumberFieldTest.php
+++ b/tests/wpunit/QuantityNumberFieldTest.php
@@ -20,28 +20,32 @@ class QuantityNumberFieldTest extends FormFieldTestCase implements FormFieldTest
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -78,7 +82,7 @@ class QuantityNumberFieldTest extends FormFieldTestCase implements FormFieldTest
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [
 			$this->factory->field->create(
 				array_merge(
@@ -108,10 +112,9 @@ class QuantityNumberFieldTest extends FormFieldTestCase implements FormFieldTest
 		];
 	}
 
-	public function mutation_value_field_id() : int {
+	public function mutation_value_field_id(): int {
 		return $this->fields[1]->id;
 	}
-
 
 	/**
 	 * The value as expected in GraphQL.
@@ -135,7 +138,6 @@ class QuantityNumberFieldTest extends FormFieldTestCase implements FormFieldTest
 		return $this->updated_field_value;
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -149,10 +151,8 @@ class QuantityNumberFieldTest extends FormFieldTestCase implements FormFieldTest
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on QuantityField {
 				adminLabel
@@ -195,7 +195,7 @@ class QuantityNumberFieldTest extends FormFieldTestCase implements FormFieldTest
 	/**
 	 * SubmitForm mutation string.
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ($formId: ID!, $fieldId: Int!, $value: String!, $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: {id: $fieldId, value: $value}}) {
@@ -226,7 +226,7 @@ class QuantityNumberFieldTest extends FormFieldTestCase implements FormFieldTest
 	/**
 	 * Returns the UpdateEntry mutation string.
 	 */
-	public function update_entry_mutation() : string {
+	public function update_entry_mutation(): string {
 		return '
 			mutation updateGfEntry( $entryId: ID!, $fieldId: Int!, $value: String! ){
 				updateGfEntry( input: { id: $entryId, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -252,7 +252,7 @@ class QuantityNumberFieldTest extends FormFieldTestCase implements FormFieldTest
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
 	 */
-	public function update_draft_entry_mutation() : string {
+	public function update_draft_entry_mutation(): string {
 		return '
 			mutation updateGfDraftEntry( $resumeToken: ID!, $fieldId: Int!, $value: String! ){
 				updateGfDraftEntry( input: {id: $resumeToken, idType: RESUME_TOKEN, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -275,11 +275,9 @@ class QuantityNumberFieldTest extends FormFieldTestCase implements FormFieldTest
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][1] );
 		$expected[] = $this->expected_field_value( 'value', $this->field_value );
 
@@ -307,9 +305,8 @@ class QuantityNumberFieldTest extends FormFieldTestCase implements FormFieldTest
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,
@@ -336,7 +333,7 @@ class QuantityNumberFieldTest extends FormFieldTestCase implements FormFieldTest
 	 * @param array $actual_entry .
 	 * @param array $form .
 	 */
-	public function check_saved_values( $actual_entry, $form ) : void {
+	public function check_saved_values( $actual_entry, $form ): void {
 		$this->assertEquals( $this->field_value, $actual_entry[ $form['fields'][1]->id ], 'Submit mutation entry value not equal' );
 	}
 }

--- a/tests/wpunit/QuantitySelectFieldTest.php
+++ b/tests/wpunit/QuantitySelectFieldTest.php
@@ -20,28 +20,32 @@ class QuantitySelectFieldTest extends FormFieldTestCase implements FormFieldTest
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -80,7 +84,7 @@ class QuantitySelectFieldTest extends FormFieldTestCase implements FormFieldTest
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [
 			$this->factory->field->create(
 				array_merge(
@@ -136,7 +140,7 @@ class QuantitySelectFieldTest extends FormFieldTestCase implements FormFieldTest
 		];
 	}
 
-	public function mutation_value_field_id() : int {
+	public function mutation_value_field_id(): int {
 		return $this->fields[1]->id;
 	}
 
@@ -162,7 +166,6 @@ class QuantitySelectFieldTest extends FormFieldTestCase implements FormFieldTest
 		return $this->updated_field_value;
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -176,10 +179,8 @@ class QuantitySelectFieldTest extends FormFieldTestCase implements FormFieldTest
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on QuantityField {
 				adminLabel
@@ -227,7 +228,7 @@ class QuantitySelectFieldTest extends FormFieldTestCase implements FormFieldTest
 	/**
 	 * SubmitForm mutation string.
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ($formId: ID!, $fieldId: Int!, $value: String!, $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: {id: $fieldId, value: $value}}) {
@@ -258,7 +259,7 @@ class QuantitySelectFieldTest extends FormFieldTestCase implements FormFieldTest
 	/**
 	 * Returns the UpdateEntry mutation string.
 	 */
-	public function update_entry_mutation() : string {
+	public function update_entry_mutation(): string {
 		return '
 			mutation updateGfEntry( $entryId: ID!, $fieldId: Int!, $value: String! ){
 				updateGfEntry( input: { id: $entryId, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -284,7 +285,7 @@ class QuantitySelectFieldTest extends FormFieldTestCase implements FormFieldTest
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
 	 */
-	public function update_draft_entry_mutation() : string {
+	public function update_draft_entry_mutation(): string {
 		return '
 			mutation updateGfDraftEntry( $resumeToken: ID!, $fieldId: Int!, $value: String! ){
 				updateGfDraftEntry( input: {id: $resumeToken, idType: RESUME_TOKEN, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -307,11 +308,9 @@ class QuantitySelectFieldTest extends FormFieldTestCase implements FormFieldTest
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][1] );
 		$expected[] = $this->expected_field_value( 'value', $this->field_value );
 
@@ -339,9 +338,8 @@ class QuantitySelectFieldTest extends FormFieldTestCase implements FormFieldTest
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,
@@ -368,7 +366,7 @@ class QuantitySelectFieldTest extends FormFieldTestCase implements FormFieldTest
 	 * @param array $actual_entry .
 	 * @param array $form .
 	 */
-	public function check_saved_values( $actual_entry, $form ) : void {
+	public function check_saved_values( $actual_entry, $form ): void {
 		$this->assertEquals( $this->field_value, $actual_entry[ $form['fields'][1]->id ], 'Submit mutation entry value not equal' );
 	}
 }

--- a/tests/wpunit/QuizCheckboxFieldTest.php
+++ b/tests/wpunit/QuizCheckboxFieldTest.php
@@ -17,28 +17,32 @@ class QuizCheckboxFieldTest extends FormFieldTestCase implements FormFieldTestCa
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -52,7 +56,7 @@ class QuizCheckboxFieldTest extends FormFieldTestCase implements FormFieldTestCa
 	/**
 	 * Generates the form fields from factory. Must be wrapped in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [
 			$this->factory->field->create(
 				array_merge(
@@ -159,6 +163,7 @@ class QuizCheckboxFieldTest extends FormFieldTestCase implements FormFieldTestCa
 			],
 		];
 	}
+
 	/**
 	 * The graphql field value input.
 	 */
@@ -179,8 +184,6 @@ class QuizCheckboxFieldTest extends FormFieldTestCase implements FormFieldTestCa
 			],
 		];
 	}
-
-
 
 	/**
 	 * The value as expected in GraphQL when updating from field_value().
@@ -215,13 +218,10 @@ class QuizCheckboxFieldTest extends FormFieldTestCase implements FormFieldTestCa
 		];
 	}
 
-
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query():string {
+	public function field_query(): string {
 		return '... on QuizField {
 				adminLabel
 				answerExplanation
@@ -375,9 +375,7 @@ class QuizCheckboxFieldTest extends FormFieldTestCase implements FormFieldTestCa
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
 	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
@@ -407,9 +405,8 @@ class QuizCheckboxFieldTest extends FormFieldTestCase implements FormFieldTestCa
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ):array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,

--- a/tests/wpunit/QuizRadioFieldTest.php
+++ b/tests/wpunit/QuizRadioFieldTest.php
@@ -17,28 +17,32 @@ class QuizRadioFieldTest extends FormFieldTestCase implements FormFieldTestCaseI
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -52,7 +56,7 @@ class QuizRadioFieldTest extends FormFieldTestCase implements FormFieldTestCaseI
 	/**
 	 * Generates the form fields from factory. Must be wrapped in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [
 			$this->factory->field->create(
 				array_merge(
@@ -110,14 +114,13 @@ class QuizRadioFieldTest extends FormFieldTestCase implements FormFieldTestCaseI
 	public function field_value_input() {
 		return $this->fields[0]['choices'][0]['text'];
 	}
+
 	/**
 	 * The graphql field value input.
 	 */
 	public function updated_field_value_input() {
 		return $this->fields[0]['choices'][2]['text'];
 	}
-
-
 
 	/**
 	 * The value as expected in GraphQL when updating from field_value().
@@ -126,7 +129,6 @@ class QuizRadioFieldTest extends FormFieldTestCase implements FormFieldTestCaseI
 		return $this->fields[0]['choices'][2]['text'];
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -134,13 +136,10 @@ class QuizRadioFieldTest extends FormFieldTestCase implements FormFieldTestCaseI
 		return [ (string) $this->fields[0]['id'] => $this->field_value_input ];
 	}
 
-
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query():string {
+	public function field_query(): string {
 		return '... on QuizField {
 				adminLabel
 				answerExplanation
@@ -272,9 +271,7 @@ class QuizRadioFieldTest extends FormFieldTestCase implements FormFieldTestCaseI
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
 	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
@@ -304,9 +301,8 @@ class QuizRadioFieldTest extends FormFieldTestCase implements FormFieldTestCaseI
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ):array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,

--- a/tests/wpunit/QuizSelectFieldTest.php
+++ b/tests/wpunit/QuizSelectFieldTest.php
@@ -17,28 +17,32 @@ class QuizSelectFieldTest extends FormFieldTestCase implements FormFieldTestCase
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -52,7 +56,7 @@ class QuizSelectFieldTest extends FormFieldTestCase implements FormFieldTestCase
 	/**
 	 * Generates the form fields from factory. Must be wrapped in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [
 			$this->factory->field->create(
 				array_merge(
@@ -111,7 +115,6 @@ class QuizSelectFieldTest extends FormFieldTestCase implements FormFieldTestCase
 		return $this->fields[0]['choices'][2]['value'];
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -119,13 +122,10 @@ class QuizSelectFieldTest extends FormFieldTestCase implements FormFieldTestCase
 		return [ $this->fields[0]['id'] => $this->field_value ];
 	}
 
-
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query():string {
+	public function field_query(): string {
 		return '... on QuizField {
 				adminLabel
 				answerExplanation
@@ -262,9 +262,7 @@ class QuizSelectFieldTest extends FormFieldTestCase implements FormFieldTestCase
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
 	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
@@ -294,9 +292,8 @@ class QuizSelectFieldTest extends FormFieldTestCase implements FormFieldTestCase
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ):array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,

--- a/tests/wpunit/RadioFieldTest.php
+++ b/tests/wpunit/RadioFieldTest.php
@@ -12,37 +12,42 @@ use Tests\WPGraphQL\GF\TestCase\FormFieldTestCaseInterface;
 /**
  * Class -RadioFieldTest.
  */
-class RadioFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInterface {
+class RadioFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterface {
 	/**
 	 * Tests the field properties and values.
 	 */
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
+
 	/**
 	 * Sets the correct Field Helper.
 	 */
@@ -53,7 +58,7 @@ class RadioFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInte
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [ $this->factory->field->create( $this->property_helper->values ) ];
 	}
 
@@ -71,7 +76,6 @@ class RadioFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInte
 		return $this->fields[0]['choices'][2]['value'];
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -81,10 +85,8 @@ class RadioFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInte
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '... on RadioField {
 				adminLabel
 				canPrepopulate
@@ -129,7 +131,7 @@ class RadioFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInte
 	/**
 	 * SubmitForm mutation string.
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ($formId: ID!, $fieldId: Int!, $value: String!, $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: {id: $fieldId, value: $value}}) {
@@ -160,7 +162,7 @@ class RadioFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInte
 	/**
 	 * Returns the UpdateEntry mutation string.
 	 */
-	public function update_entry_mutation() : string {
+	public function update_entry_mutation(): string {
 		return '
 			mutation updateGfEntry( $entryId: ID!, $fieldId: Int!, $value: String! ){
 				updateGfEntry( input: { id: $entryId, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -185,7 +187,7 @@ class RadioFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInte
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
 	 */
-	public function update_draft_entry_mutation() : string {
+	public function update_draft_entry_mutation(): string {
 		return '
 			mutation updateGfDraftEntry( $resumeToken: ID!, $fieldId: Int!, $value: String! ){
 				updateGfDraftEntry( input: {id: $resumeToken, idType: RESUME_TOKEN, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -208,11 +210,9 @@ class RadioFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInte
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
 		$expected[] = $this->expected_field_value( 'value', $this->field_value );
 
@@ -240,9 +240,8 @@ class RadioFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInte
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,
@@ -274,7 +273,7 @@ class RadioFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInte
 	 * @param array $actual_entry .
 	 * @param array $form .
 	 */
-	public function check_saved_values( $actual_entry, $form ) : void {
+	public function check_saved_values( $actual_entry, $form ): void {
 		$this->assertEquals( $this->field_value, $actual_entry[ $form['fields'][0]->id ], 'Submit mutation entry value not equal' );
 	}
 }

--- a/tests/wpunit/SectionFieldTest.php
+++ b/tests/wpunit/SectionFieldTest.php
@@ -28,7 +28,7 @@ class SectionFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [ $this->factory->field->create( $this->property_helper->values ) ];
 	}
 
@@ -44,7 +44,6 @@ class SectionFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 	public function updated_field_value() {
 		return ''; }
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -54,10 +53,8 @@ class SectionFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on SectionField {
 				conditionalLogic {
@@ -78,29 +75,27 @@ class SectionFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 	/**
 	 * SubmitForm mutation string.
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return ''; }
 
 	/**
 	 * Returns the UpdateEntry mutation string.
 	 */
-	public function update_entry_mutation() : string {
+	public function update_entry_mutation(): string {
 		return '';
 	}
 
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
 	 */
-	public function update_draft_entry_mutation() : string {
+	public function update_draft_entry_mutation(): string {
 		return '';
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected = $this->getExpectedFormFieldValues( $form['fields'][0] );
 
 		return [
@@ -127,9 +122,8 @@ class SectionFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [];
 	}
 
@@ -139,5 +133,5 @@ class SectionFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 	 * @param array $actual_entry .
 	 * @param array $form .
 	 */
-	public function check_saved_values( $actual_entry, $form ) : void {}
+	public function check_saved_values( $actual_entry, $form ): void {}
 }

--- a/tests/wpunit/SelectFieldTest.php
+++ b/tests/wpunit/SelectFieldTest.php
@@ -12,37 +12,42 @@ use Tests\WPGraphQL\GF\TestCase\FormFieldTestCaseInterface;
 /**
  * Class -SelectFieldTest.
  */
-class SelectFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInterface {
+class SelectFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterface {
 	/**
 	 * Tests the field properties and values.
 	 */
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
+
 	/**
 	 * Sets the correct Field Helper.
 	 */
@@ -53,7 +58,7 @@ class SelectFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInt
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [ $this->factory->field->create( $this->property_helper->values ) ];
 	}
 
@@ -71,7 +76,6 @@ class SelectFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInt
 		return $this->fields[0]['choices'][2]['value'];
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -81,10 +85,8 @@ class SelectFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInt
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on SelectField {
 				adminLabel
@@ -134,7 +136,7 @@ class SelectFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInt
 	/**
 	 * SubmitForm mutation string.
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ($formId: ID!, $fieldId: Int!, $value: String!, $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: {id: $fieldId, value: $value}}) {
@@ -165,7 +167,7 @@ class SelectFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInt
 	/**
 	 * Returns the UpdateEntry mutation string.
 	 */
-	public function update_entry_mutation() : string {
+	public function update_entry_mutation(): string {
 		return '
 			mutation updateGfEntry( $entryId: ID!, $fieldId: Int!, $value: String! ){
 				updateGfEntry( input: { id: $entryId, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -190,7 +192,7 @@ class SelectFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInt
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
 	 */
-	public function update_draft_entry_mutation() : string {
+	public function update_draft_entry_mutation(): string {
 		return '
 			mutation updateGfDraftEntry( $resumeToken: ID!, $fieldId: Int!, $value: String! ){
 				updateGfDraftEntry( input: {id: $resumeToken, idType: RESUME_TOKEN, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -213,11 +215,9 @@ class SelectFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInt
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
 		$expected[] = $this->expected_field_value( 'value', $this->field_value );
 
@@ -245,9 +245,8 @@ class SelectFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInt
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,
@@ -279,7 +278,7 @@ class SelectFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInt
 	 * @param array $actual_entry .
 	 * @param array $form .
 	 */
-	public function check_saved_values( $actual_entry, $form ) : void {
+	public function check_saved_values( $actual_entry, $form ): void {
 		$this->assertEquals( $this->field_value, $actual_entry[ $form['fields'][0]->id ], 'Submit mutation entry value not equal' );
 	}
 }

--- a/tests/wpunit/SettingsTest.php
+++ b/tests/wpunit/SettingsTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Helper\GFHelpers\GFHelpers;
-use WPGraphQL\GF\GF;
 use WPGraphQL\GF\Type\Enum\RecaptchaTypeEnum;
 
 class SettingsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
@@ -10,10 +9,11 @@ class SettingsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 	 */
 	protected $tester;
 	public $instance;
+
 	/**
 	 * Provides access to dummy functions.
 	 *
-	 * @var Dummy
+	 * @var \Dummy
 	 */
 	public $dummy;
 	public array $options;
@@ -91,7 +91,7 @@ class SettingsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertQuerySuccessful( $response, $expected );
 	}
 
-	public function expected_field_response() : array {
+	public function expected_field_response(): array {
 		return [
 			$this->expectedObject(
 				'gfSettings',

--- a/tests/wpunit/ShippingRadioFieldTest.php
+++ b/tests/wpunit/ShippingRadioFieldTest.php
@@ -17,28 +17,32 @@ class ShippingRadioFieldTest extends FormFieldTestCase implements FormFieldTestC
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -63,7 +67,7 @@ class ShippingRadioFieldTest extends FormFieldTestCase implements FormFieldTestC
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [
 			$this->factory->field->create(
 				array_merge(
@@ -110,7 +114,6 @@ class ShippingRadioFieldTest extends FormFieldTestCase implements FormFieldTestC
 		return $this->fields[0]['choices'][2]['value'];
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -120,10 +123,8 @@ class ShippingRadioFieldTest extends FormFieldTestCase implements FormFieldTestC
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on ShippingField {
 				adminLabel
@@ -165,7 +166,7 @@ class ShippingRadioFieldTest extends FormFieldTestCase implements FormFieldTestC
 	/**
 	 * SubmitForm mutation string.
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ($formId: ID!, $fieldId: Int!, $value: String!, $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: {id: $fieldId, value: $value}}) {
@@ -196,7 +197,7 @@ class ShippingRadioFieldTest extends FormFieldTestCase implements FormFieldTestC
 	/**
 	 * Returns the UpdateEntry mutation string.
 	 */
-	public function update_entry_mutation() : string {
+	public function update_entry_mutation(): string {
 		return '
 			mutation updateGfEntry( $entryId: ID!, $fieldId: Int!, $value: String! ){
 				updateGfEntry( input: { id: $entryId, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -221,7 +222,7 @@ class ShippingRadioFieldTest extends FormFieldTestCase implements FormFieldTestC
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
 	 */
-	public function update_draft_entry_mutation() : string {
+	public function update_draft_entry_mutation(): string {
 		return '
 			mutation updateGfDraftEntry( $resumeToken: ID!, $fieldId: Int!, $value: String! ){
 				updateGfDraftEntry( input: {id: $resumeToken, idType: RESUME_TOKEN, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -244,11 +245,9 @@ class ShippingRadioFieldTest extends FormFieldTestCase implements FormFieldTestC
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
 		$expected[] = $this->expected_field_value( 'value', $this->field_value );
 
@@ -276,9 +275,8 @@ class ShippingRadioFieldTest extends FormFieldTestCase implements FormFieldTestC
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,
@@ -310,7 +308,7 @@ class ShippingRadioFieldTest extends FormFieldTestCase implements FormFieldTestC
 	 * @param array $actual_entry .
 	 * @param array $form .
 	 */
-	public function check_saved_values( $actual_entry, $form ) : void {
+	public function check_saved_values( $actual_entry, $form ): void {
 		$this->assertEquals( $this->field_value, $actual_entry[ $form['fields'][0]->id ], 'Submit mutation entry value not equal' );
 	}
 }

--- a/tests/wpunit/ShippingSelectFieldTest.php
+++ b/tests/wpunit/ShippingSelectFieldTest.php
@@ -17,28 +17,32 @@ class ShippingSelectFieldTest extends FormFieldTestCase implements FormFieldTest
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -65,7 +69,7 @@ class ShippingSelectFieldTest extends FormFieldTestCase implements FormFieldTest
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [
 			$this->factory->field->create(
 				array_merge(
@@ -112,7 +116,6 @@ class ShippingSelectFieldTest extends FormFieldTestCase implements FormFieldTest
 		return $this->fields[0]['choices'][2]['value'];
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -122,10 +125,8 @@ class ShippingSelectFieldTest extends FormFieldTestCase implements FormFieldTest
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on ShippingField {
 				adminLabel
@@ -171,7 +172,7 @@ class ShippingSelectFieldTest extends FormFieldTestCase implements FormFieldTest
 	/**
 	 * SubmitForm mutation string.
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ($formId: ID!, $fieldId: Int!, $value: String!, $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: {id: $fieldId, value: $value}}) {
@@ -202,7 +203,7 @@ class ShippingSelectFieldTest extends FormFieldTestCase implements FormFieldTest
 	/**
 	 * Returns the UpdateEntry mutation string.
 	 */
-	public function update_entry_mutation() : string {
+	public function update_entry_mutation(): string {
 		return '
 			mutation updateGfEntry( $entryId: ID!, $fieldId: Int!, $value: String! ){
 				updateGfEntry( input: { id: $entryId, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -227,7 +228,7 @@ class ShippingSelectFieldTest extends FormFieldTestCase implements FormFieldTest
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
 	 */
-	public function update_draft_entry_mutation() : string {
+	public function update_draft_entry_mutation(): string {
 		return '
 			mutation updateGfDraftEntry( $resumeToken: ID!, $fieldId: Int!, $value: String! ){
 				updateGfDraftEntry( input: {id: $resumeToken, idType: RESUME_TOKEN, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -250,11 +251,9 @@ class ShippingSelectFieldTest extends FormFieldTestCase implements FormFieldTest
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
 		$expected[] = $this->expected_field_value( 'value', $this->field_value );
 
@@ -282,9 +281,8 @@ class ShippingSelectFieldTest extends FormFieldTestCase implements FormFieldTest
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,
@@ -316,7 +314,7 @@ class ShippingSelectFieldTest extends FormFieldTestCase implements FormFieldTest
 	 * @param array $actual_entry .
 	 * @param array $form .
 	 */
-	public function check_saved_values( $actual_entry, $form ) : void {
+	public function check_saved_values( $actual_entry, $form ): void {
 		$this->assertEquals( $this->field_value, $actual_entry[ $form['fields'][0]->id ], 'Submit mutation entry value not equal' );
 	}
 }

--- a/tests/wpunit/ShippingSingleFieldTest.php
+++ b/tests/wpunit/ShippingSingleFieldTest.php
@@ -17,28 +17,32 @@ class ShippingSingleFieldTest extends FormFieldTestCase implements FormFieldTest
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -52,7 +56,7 @@ class ShippingSingleFieldTest extends FormFieldTestCase implements FormFieldTest
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [
 			$this->factory->field->create(
 				array_merge(
@@ -77,7 +81,6 @@ class ShippingSingleFieldTest extends FormFieldTestCase implements FormFieldTest
 		return $this->property_helper->basePrice();
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -87,10 +90,8 @@ class ShippingSingleFieldTest extends FormFieldTestCase implements FormFieldTest
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on ShippingField {
 				adminLabel
@@ -119,7 +120,7 @@ class ShippingSingleFieldTest extends FormFieldTestCase implements FormFieldTest
 	/**
 	 * SubmitForm mutation string.
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ($formId: ID!, $fieldId: Int!, $value: String!, $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: {id: $fieldId, value: $value}}) {
@@ -150,7 +151,7 @@ class ShippingSingleFieldTest extends FormFieldTestCase implements FormFieldTest
 	/**
 	 * Returns the UpdateEntry mutation string.
 	 */
-	public function update_entry_mutation() : string {
+	public function update_entry_mutation(): string {
 		return '
 			mutation updateGfEntry( $entryId: ID!, $fieldId: Int!, $value: String! ){
 				updateGfEntry( input: { id: $entryId, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -175,7 +176,7 @@ class ShippingSingleFieldTest extends FormFieldTestCase implements FormFieldTest
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
 	 */
-	public function update_draft_entry_mutation() : string {
+	public function update_draft_entry_mutation(): string {
 		return '
 			mutation updateGfDraftEntry( $resumeToken: ID!, $fieldId: Int!, $value: String! ){
 				updateGfDraftEntry( input: {id: $resumeToken, idType: RESUME_TOKEN, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -198,11 +199,9 @@ class ShippingSingleFieldTest extends FormFieldTestCase implements FormFieldTest
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
 		$expected[] = $this->expected_field_value( 'value', $this->field_value );
 
@@ -230,9 +229,8 @@ class ShippingSingleFieldTest extends FormFieldTestCase implements FormFieldTest
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,
@@ -264,7 +262,7 @@ class ShippingSingleFieldTest extends FormFieldTestCase implements FormFieldTest
 	 * @param array $actual_entry .
 	 * @param array $form .
 	 */
-	public function check_saved_values( $actual_entry, $form ) : void {
+	public function check_saved_values( $actual_entry, $form ): void {
 		$this->assertEquals( $this->field_value, $actual_entry[ $form['fields'][0]->id ], 'Submit mutation entry value not equal' );
 	}
 }

--- a/tests/wpunit/SignatureFieldTest.php
+++ b/tests/wpunit/SignatureFieldTest.php
@@ -11,37 +11,42 @@ use Tests\WPGraphQL\GF\TestCase\FormFieldTestCaseInterface;
 /**
  * Class -SignatureFieldTest.
  */
-class SignatureFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInterface {
+class SignatureFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterface {
 	/**
 	 * Tests the field properties and values.
 	 */
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
+
 	/**
 	 * Sets the correct Field Helper.
 	 */
@@ -52,7 +57,7 @@ class SignatureFieldTest  extends FormFieldTestCase implements FormFieldTestCase
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [ $this->factory->field->create( $this->property_helper->values ) ];
 	}
 
@@ -87,10 +92,8 @@ class SignatureFieldTest  extends FormFieldTestCase implements FormFieldTestCase
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on SignatureField {
 				adminLabel
@@ -130,7 +133,7 @@ class SignatureFieldTest  extends FormFieldTestCase implements FormFieldTestCase
 	/**
 	 * SubmitForm mutation string.
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ($formId: ID!, $fieldId: Int!, $value: String!, $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: {id: $fieldId, value: $value}}) {
@@ -161,7 +164,7 @@ class SignatureFieldTest  extends FormFieldTestCase implements FormFieldTestCase
 	/**
 	 * Returns the UpdateEntry mutation string.
 	 */
-	public function update_entry_mutation() : string {
+	public function update_entry_mutation(): string {
 		return '
 			mutation updateGfEntry( $entryId: ID!, $fieldId: Int!, $value: String! ){
 				updateGfEntry( input: { id: $entryId, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -186,7 +189,7 @@ class SignatureFieldTest  extends FormFieldTestCase implements FormFieldTestCase
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
 	 */
-	public function update_draft_entry_mutation() : string {
+	public function update_draft_entry_mutation(): string {
 		return '
 			mutation updateGfDraftEntry( $resumeToken: ID!, $fieldId: Int!, $value: String! ){
 				updateGfDraftEntry( input: {id: $resumeToken, idType: RESUME_TOKEN, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -209,11 +212,9 @@ class SignatureFieldTest  extends FormFieldTestCase implements FormFieldTestCase
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected = $this->getExpectedFormFieldValues( $form['fields'][0] );
 		// $expected[] = $this->expected_field_value( 'value', $this->factory->entry->get_object_by_id( $this->entry_id )[ $form['fields'][0]->id ] );
 
@@ -241,9 +242,8 @@ class SignatureFieldTest  extends FormFieldTestCase implements FormFieldTestCase
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,
@@ -257,7 +257,7 @@ class SignatureFieldTest  extends FormFieldTestCase implements FormFieldTestCase
 									$this->expectedNode(
 										'nodes',
 										[
-											$this->expected_field_value( 'value', static::NOT_FALSY ),
+											$this->expected_field_value( 'value', self::NOT_FALSY ),
 										]
 									),
 								]
@@ -275,7 +275,7 @@ class SignatureFieldTest  extends FormFieldTestCase implements FormFieldTestCase
 	 * @param array $actual_entry .
 	 * @param array $form .
 	 */
-	public function check_saved_values( $actual_entry, $form ) : void {
+	public function check_saved_values( $actual_entry, $form ): void {
 		$this->assertStringEndsWith( $this->field_value, $actual_entry[ $form['fields'][0]->id ], 'Submit mutation entry value not equal' );
 	}
 }

--- a/tests/wpunit/SubmitDraftEntryMutationTest.php
+++ b/tests/wpunit/SubmitDraftEntryMutationTest.php
@@ -16,7 +16,6 @@ class SubmitDraftEntryMutationTest extends GFGraphQLTestCase {
 	private $draft_token;
 	private $text_field_helper;
 
-
 	/**
 	 * Run before each test.
 	 */
@@ -57,7 +56,7 @@ class SubmitDraftEntryMutationTest extends GFGraphQLTestCase {
 	/**
 	 * Tests `submitGfDraft
 	 */
-	public function testSubmitGravityFormsDraftEntry() : void {
+	public function testSubmitGravityFormsDraftEntry(): void {
 		$query = $this->submit_mutation();
 
 		$variables = [
@@ -80,7 +79,7 @@ class SubmitDraftEntryMutationTest extends GFGraphQLTestCase {
 		$this->factory->entry->delete( $expected['id'] );
 	}
 
-	public function testSubmitWithUrlConfirmation() : void {
+	public function testSubmitWithUrlConfirmation(): void {
 		$form = GFAPI::get_form( $this->form_id );
 
 		$confirmation_id = array_keys( $form['confirmations'] )[0];
@@ -116,7 +115,7 @@ class SubmitDraftEntryMutationTest extends GFGraphQLTestCase {
 		$this->factory->entry->delete( $expected['id'] );
 	}
 
-	public function testSubmitWithPageConfirmation() : void {
+	public function testSubmitWithPageConfirmation(): void {
 		$form    = GFAPI::get_form( $this->form_id );
 		$page_id = $this->factory()->post->create(
 			[
@@ -163,7 +162,7 @@ class SubmitDraftEntryMutationTest extends GFGraphQLTestCase {
 	/**
 	 * Creates the mutation.
 	 */
-	public function submit_mutation() : string {
+	public function submit_mutation(): string {
 		return '
 			mutation submitGfDraftEntry (
 				$id: ID!

--- a/tests/wpunit/SubmitFormMutationTest.php
+++ b/tests/wpunit/SubmitFormMutationTest.php
@@ -24,12 +24,12 @@ class SubmitFormMutationTest extends GFGraphQLTestCase {
 	/**
 	 * Tests `submitGfDraft
 	 */
-	public function testSubmitFormWithEmptyFieldValues() : void {
+	public function testSubmitFormWithEmptyFieldValues(): void {
 		// Create Form.
 		$helper  = $this->tester->getPropertyHelper( 'TextField' );
 		$fields  = [ $this->factory->field->create( $helper->values ) ];
 		$form_id = $this->factory->form->create( array_merge( [ 'fields' => $fields ], $this->tester->getFormDefaultArgs() ) );
-	
+
 		$query = $this->submit_mutation();
 
 		// Test with errors.
@@ -57,7 +57,7 @@ class SubmitFormMutationTest extends GFGraphQLTestCase {
 		$this->assertNotEmpty( $actual['data']['submitGfForm']['errors'][0]['message'] );
 	}
 
-	public function testSubmitForm() : void {
+	public function testSubmitForm(): void {
 		// Create Form.
 		$helper  = $this->tester->getPropertyHelper( 'TextField' );
 		$fields  = [ $this->factory->field->create( $helper->values ) ];
@@ -103,13 +103,12 @@ class SubmitFormMutationTest extends GFGraphQLTestCase {
 		$this->assertNotEmpty( $actual['data']['submitGfForm']['entry']['sourceUrl'] );
 		$this->assertEmpty( $actual['data']['submitGfForm']['entry']['userAgent'] );
 
-
 		// Cleanup
 		$this->factory->entry->delete( $actual['data']['submitGfForm']['entry']['databaseId'] );
 		$this->factory->form->delete( $form_id );
 	}
 
-	public function testSubmitWithUrlConfirmation() : void {
+	public function testSubmitWithUrlConfirmation(): void {
 		// Create Form.
 		$helper = $this->tester->getPropertyHelper( 'TextField' );
 		$fields = [ $this->factory->field->create( $helper->values ) ];
@@ -167,7 +166,7 @@ class SubmitFormMutationTest extends GFGraphQLTestCase {
 		$this->factory->form->delete( $form_id );
 	}
 
-	public function testSubmitWithPageConfirmation() : void {
+	public function testSubmitWithPageConfirmation(): void {
 		// Create page.
 		$page_id = $this->factory()->post->create(
 			[
@@ -200,7 +199,7 @@ class SubmitFormMutationTest extends GFGraphQLTestCase {
 						],
 					],
 				]
-			) 
+			)
 		);
 
 		$query = $this->submit_mutation();
@@ -234,7 +233,7 @@ class SubmitFormMutationTest extends GFGraphQLTestCase {
 		$this->factory->form->delete( $form_id );
 	}
 
-	public function testSubmitWithLoggedInUser() : void {
+	public function testSubmitWithLoggedInUser(): void {
 		// Create Form.
 		$helper  = $this->tester->getPropertyHelper( 'TextField' );
 		$fields  = [ $this->factory->field->create( $helper->values ) ];
@@ -256,7 +255,6 @@ class SubmitFormMutationTest extends GFGraphQLTestCase {
 			],
 		];
 
-
 		wp_set_current_user( $this->admin->ID );
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
@@ -274,7 +272,7 @@ class SubmitFormMutationTest extends GFGraphQLTestCase {
 		$this->factory->form->delete( $form_id );
 	}
 
-	public function testSubmitWithEntryMeta() : void {
+	public function testSubmitWithEntryMeta(): void {
 		// Create Form.
 		$helper  = $this->tester->getPropertyHelper( 'TextField' );
 		$fields  = [ $this->factory->field->create( $helper->values ) ];
@@ -321,7 +319,7 @@ class SubmitFormMutationTest extends GFGraphQLTestCase {
 		$this->factory->form->delete( $form_id );
 	}
 
-	public function testSubmitWithPostCreation() : void {
+	public function testSubmitWithPostCreation(): void {
 		$category = $this->factory->category->create_and_get();
 		$tag      = $this->factory->tag->create_and_get();
 
@@ -489,7 +487,7 @@ class SubmitFormMutationTest extends GFGraphQLTestCase {
 		wp_delete_post( $actual['data']['submitGfForm']['entry']['post']['databaseId'], true );
 	}
 
-	public function testSubmitWithOrderItems() : void {
+	public function testSubmitWithOrderItems(): void {
 
 		// Create Form.
 		$fields = [
@@ -538,7 +536,7 @@ class SubmitFormMutationTest extends GFGraphQLTestCase {
 						]
 					)->values,
 					[
-						
+
 						'inputs' => [
 							[
 								'id'    => 2.1,
@@ -617,7 +615,7 @@ class SubmitFormMutationTest extends GFGraphQLTestCase {
 				$this->tester->getFormDefaultArgs(),
 				[
 					'fields' => $fields,
-					
+
 				],
 			)
 		);
@@ -719,7 +717,7 @@ class SubmitFormMutationTest extends GFGraphQLTestCase {
 	/**
 	 * Creates the mutation.
 	 */
-	public function submit_mutation() : string {
+	public function submit_mutation(): string {
 		return 'mutation SubmitForm( $input:SubmitGfFormInput! ) {
 			submitGfForm(input:$input) {
 				confirmation{

--- a/tests/wpunit/TextAreaFieldTest.php
+++ b/tests/wpunit/TextAreaFieldTest.php
@@ -11,37 +11,42 @@ use Tests\WPGraphQL\GF\TestCase\FormFieldTestCaseInterface;
 /**
  * Class -TextAreaFieldTest.
  */
-class TextAreaFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInterface {
+class TextAreaFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterface {
 	/**
 	 * Tests the field properties and values.
 	 */
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
+
 	/**
 	 * Sets the correct Field Helper.
 	 */
@@ -52,7 +57,7 @@ class TextAreaFieldTest  extends FormFieldTestCase implements FormFieldTestCaseI
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [ $this->factory->field->create( $this->property_helper->values ) ];
 	}
 
@@ -70,7 +75,6 @@ class TextAreaFieldTest  extends FormFieldTestCase implements FormFieldTestCaseI
 		return $this->property_helper->dummy->words( 1, 5 );
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -80,10 +84,8 @@ class TextAreaFieldTest  extends FormFieldTestCase implements FormFieldTestCaseI
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on TextAreaField {
 				adminLabel
@@ -124,7 +126,7 @@ class TextAreaFieldTest  extends FormFieldTestCase implements FormFieldTestCaseI
 	/**
 	 * SubmitForm mutation string.
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ($formId: ID!, $fieldId: Int!, $value: String!, $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: {id: $fieldId, value: $value}}) {
@@ -155,7 +157,7 @@ class TextAreaFieldTest  extends FormFieldTestCase implements FormFieldTestCaseI
 	/**
 	 * Returns the UpdateEntry mutation string.
 	 */
-	public function update_entry_mutation() : string {
+	public function update_entry_mutation(): string {
 		return '
 			mutation updateGfEntry( $entryId: ID!, $fieldId: Int!, $value: String! ){
 				updateGfEntry( input: { id: $entryId, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -180,7 +182,7 @@ class TextAreaFieldTest  extends FormFieldTestCase implements FormFieldTestCaseI
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
 	 */
-	public function update_draft_entry_mutation() : string {
+	public function update_draft_entry_mutation(): string {
 		return '
 			mutation updateGfDraftEntry( $resumeToken: ID!, $fieldId: Int!, $value: String! ){
 				updateGfDraftEntry( input: {id: $resumeToken, idType: RESUME_TOKEN, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -203,11 +205,9 @@ class TextAreaFieldTest  extends FormFieldTestCase implements FormFieldTestCaseI
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
 		$expected[] = $this->expected_field_value( 'value', $this->field_value );
 
@@ -235,9 +235,8 @@ class TextAreaFieldTest  extends FormFieldTestCase implements FormFieldTestCaseI
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,
@@ -269,7 +268,7 @@ class TextAreaFieldTest  extends FormFieldTestCase implements FormFieldTestCaseI
 	 * @param array $actual_entry .
 	 * @param array $form .
 	 */
-	public function check_saved_values( $actual_entry, $form ) : void {
+	public function check_saved_values( $actual_entry, $form ): void {
 		$this->assertEquals( $this->field_value, $actual_entry[ $form['fields'][0]->id ], 'Submit mutation entry value not equal' );
 	}
 }

--- a/tests/wpunit/TextFieldTest.php
+++ b/tests/wpunit/TextFieldTest.php
@@ -17,28 +17,32 @@ class TextFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -52,7 +56,7 @@ class TextFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [ $this->factory->field->create( $this->property_helper->values ) ];
 	}
 
@@ -70,7 +74,6 @@ class TextFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 		return $this->property_helper->dummy->words( 1, 5 );
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -80,10 +83,8 @@ class TextFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on TextField {
 				adminLabel
@@ -128,7 +129,7 @@ class TextFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	/**
 	 * SubmitForm mutation string.
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ($formId: ID!, $fieldId: Int!, $value: String!, $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: {id: $fieldId, value: $value}}) {
@@ -159,7 +160,7 @@ class TextFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	/**
 	 * Returns the UpdateEntry mutation string.
 	 */
-	public function update_entry_mutation() : string {
+	public function update_entry_mutation(): string {
 		return '
 			mutation updateGfEntry( $entryId: ID!, $fieldId: Int!, $value: String! ){
 				updateGfEntry( input: { id: $entryId, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -184,7 +185,7 @@ class TextFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
 	 */
-	public function update_draft_entry_mutation() : string {
+	public function update_draft_entry_mutation(): string {
 		return '
 			mutation updateGfDraftEntry( $resumeToken: ID!, $fieldId: Int!, $value: String! ){
 				updateGfDraftEntry( input: {id: $resumeToken, idType: RESUME_TOKEN, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -207,11 +208,9 @@ class TextFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
 		$expected[] = $this->expected_field_value( 'value', $this->field_value );
 
@@ -239,9 +238,8 @@ class TextFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,
@@ -273,7 +271,7 @@ class TextFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 	 * @param array $actual_entry .
 	 * @param array $form .
 	 */
-	public function check_saved_values( $actual_entry, $form ) : void {
+	public function check_saved_values( $actual_entry, $form ): void {
 		$this->assertEquals( $this->field_value, $actual_entry[ $form['fields'][0]->id ], 'Submit mutation entry value not equal' );
 	}
 }

--- a/tests/wpunit/TimeFieldTest.php
+++ b/tests/wpunit/TimeFieldTest.php
@@ -12,37 +12,42 @@ use Tests\WPGraphQL\GF\TestCase\FormFieldTestCaseInterface;
 /**
  * Class -TimeFieldTest.
  */
-class TimeFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInterface {
+class TimeFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterface {
 	/**
 	 * Tests the field properties and values.
 	 */
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
+
 	/**
 	 * Sets the correct Field Helper.
 	 */
@@ -53,7 +58,7 @@ class TimeFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInter
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [ $this->factory->field->create( $this->property_helper->values ) ];
 	}
 
@@ -89,7 +94,6 @@ class TimeFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInter
 		return $this->updated_field_value['displayValue'];
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -99,10 +103,8 @@ class TimeFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInter
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on TimeField {
 				adminLabel
@@ -154,7 +156,7 @@ class TimeFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInter
 	/**
 	 * SubmitForm mutation string.
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ($formId: ID!, $fieldId: Int!, $value: String!, $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: {id: $fieldId, value: $value}}) {
@@ -190,7 +192,7 @@ class TimeFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInter
 	/**
 	 * Returns the UpdateEntry mutation string.
 	 */
-	public function update_entry_mutation() : string {
+	public function update_entry_mutation(): string {
 		return '
 			mutation updateGfEntry( $entryId: ID!, $fieldId: Int!, $value: String! ){
 				updateGfEntry( input: { id: $entryId, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -220,7 +222,7 @@ class TimeFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInter
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
 	 */
-	public function update_draft_entry_mutation() : string {
+	public function update_draft_entry_mutation(): string {
 		return '
 			mutation updateGfDraftEntry( $resumeToken: ID!, $fieldId: Int!, $value: String! ){
 				updateGfDraftEntry( input: {id: $resumeToken, idType: RESUME_TOKEN, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -248,11 +250,9 @@ class TimeFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInter
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
 		$expected[] = $this->expected_field_value( 'timeValues', $this->field_value );
 
@@ -280,9 +280,8 @@ class TimeFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInter
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,
@@ -314,7 +313,7 @@ class TimeFieldTest  extends FormFieldTestCase implements FormFieldTestCaseInter
 	 * @param array $actual_entry .
 	 * @param array $form .
 	 */
-	public function check_saved_values( $actual_entry, $form ) : void {
+	public function check_saved_values( $actual_entry, $form ): void {
 		$this->assertEquals( $this->field_value['displayValue'], $actual_entry[ $form['fields'][0]->id ], 'Submit mutation entry value not equal' );
 	}
 }

--- a/tests/wpunit/TotalFieldTest.php
+++ b/tests/wpunit/TotalFieldTest.php
@@ -20,28 +20,32 @@ class TotalFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -68,7 +72,7 @@ class TotalFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [
 			$this->factory->field->create(
 				array_merge(
@@ -98,10 +102,9 @@ class TotalFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 		];
 	}
 
-	public function mutation_value_field_id() : int {
+	public function mutation_value_field_id(): int {
 		return $this->fields[1]->id;
 	}
-
 
 	/**
 	 * The value as expected in GraphQL.
@@ -125,7 +128,6 @@ class TotalFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 		return '$' . (string) $this->updated_field_value;
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -140,10 +142,8 @@ class TotalFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on TotalField {
 				adminLabel
@@ -166,7 +166,7 @@ class TotalFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 	/**
 	 * SubmitForm mutation string.
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ($formId: ID!, $fieldId: Int!, $value: String!, $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: [
@@ -200,7 +200,7 @@ class TotalFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 	/**
 	 * Returns the UpdateEntry mutation string.
 	 */
-	public function update_entry_mutation() : string {
+	public function update_entry_mutation(): string {
 		return '
 			mutation updateGfEntry( $entryId: ID!, $fieldId: Int!, $value: String! ){
 				updateGfEntry( input: { id: $entryId, shouldValidate: true, fieldValues: [
@@ -229,7 +229,7 @@ class TotalFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
 	 */
-	public function update_draft_entry_mutation() : string {
+	public function update_draft_entry_mutation(): string {
 		return '
 			mutation updateGfDraftEntry( $resumeToken: ID!, $fieldId: Int!, $value: String! ){
 				updateGfDraftEntry( input: {id: $resumeToken, idType: RESUME_TOKEN, shouldValidate: true, fieldValues: [
@@ -255,11 +255,9 @@ class TotalFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][1] );
 		$expected[] = $this->expected_field_value( 'value', $this->field_value );
 
@@ -287,9 +285,8 @@ class TotalFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,
@@ -316,7 +313,7 @@ class TotalFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 	 * @param array $actual_entry .
 	 * @param array $form .
 	 */
-	public function check_saved_values( $actual_entry, $form ) : void {
+	public function check_saved_values( $actual_entry, $form ): void {
 		$this->assertEquals( $this->field_value, $actual_entry[ $form['fields'][1]->id ], 'Submit mutation entry value not equal' );
 	}
 }

--- a/tests/wpunit/UpdateDraftEntryMutationTest.php
+++ b/tests/wpunit/UpdateDraftEntryMutationTest.php
@@ -18,7 +18,6 @@ class UpdateDraftEntryMutationTest extends GFGraphQLTestCase {
 	private $draft_token;
 	private $text_field_helper;
 
-
 	/**
 	 * Run before each test.
 	 */
@@ -60,7 +59,7 @@ class UpdateDraftEntryMutationTest extends GFGraphQLTestCase {
 	/**
 	 * Tests `updateGfDraft
 	 */
-	public function testUpdateGfDraftEntry() : void {
+	public function testUpdateGfDraftEntry(): void {
 		$query = $this->update_mutation();
 
 		$variables = [
@@ -95,7 +94,7 @@ class UpdateDraftEntryMutationTest extends GFGraphQLTestCase {
 		$this->assertEquals( $variables['fieldValues'][0]['value'], $response['data']['updateGfDraftEntry']['draftEntry']['formFields']['nodes'][0]['value'], 'Field values dont match' );
 	}
 
-	public function update_mutation() : string {
+	public function update_mutation(): string {
 		return '
 			mutation updateGfDraftEntry (
 				$id: ID!,

--- a/tests/wpunit/UpdateEntryMutationTest.php
+++ b/tests/wpunit/UpdateEntryMutationTest.php
@@ -9,7 +9,6 @@ use Helper\GFHelpers\GFHelpers;
 use Tests\WPGraphQL\GF\TestCase\GFGraphQLTestCase;
 use WPGraphQL\GF\Data\Loader\EntriesLoader;
 use WPGraphQL\GF\Type\Enum\EntryStatusEnum;
-use WPGraphQL\GF\Utils\GFUtils;
 
 /**
  * Class - UpdateEntryMutationTest
@@ -19,7 +18,6 @@ class UpdateEntryMutationTest extends GFGraphQLTestCase {
 	private $form_id;
 	private $entry_id;
 	private $text_field_helper;
-
 
 	/**
 	 * Run before each test.
@@ -60,7 +58,7 @@ class UpdateEntryMutationTest extends GFGraphQLTestCase {
 	/**
 	 * Tests `updateGfDraft
 	 */
-	public function testUpdateGfEntry() : void {
+	public function testUpdateGfEntry(): void {
 		$query = $this->update_mutation();
 
 		$variables = [
@@ -110,7 +108,7 @@ class UpdateEntryMutationTest extends GFGraphQLTestCase {
 		$this->assertEquals( $variables['fieldValues'][0]['value'], $response['data']['updateGfEntry']['entry']['formFields']['nodes'][0]['value'], 'Field values dont match' );
 	}
 
-	public function update_mutation() : string {
+	public function update_mutation(): string {
 		return '
 			mutation updateGfEntry (
 				$id: ID!,

--- a/tests/wpunit/WebsiteFieldTest.php
+++ b/tests/wpunit/WebsiteFieldTest.php
@@ -17,28 +17,32 @@ class WebsiteFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 	public function testField(): void {
 		$this->runTestField();
 	}
+
 	/**
 	 * Tests submitting the field values as a draft entry with submitGfForm.
 	 */
 	public function testSubmitDraft(): void {
 		$this->runTestSubmitDraft();
 	}
+
 	/**
 	 * Tests submitting the field values as an entry with submitGfForm.
 	 */
 	public function testSubmitForm(): void {
 		$this->runtestSubmitForm();
 	}
+
 	/**
 	 * Tests updating the field value with updateGfEntry.
 	 */
 	public function testUpdateEntry(): void {
 		$this->runtestUpdateEntry();
 	}
+
 	/**
 	 * Tests updating the draft field value with updateGfEntry.
 	 */
-	public function testUpdateDraft():void {
+	public function testUpdateDraft(): void {
 		$this->runTestUpdateDraft();
 	}
 
@@ -52,7 +56,7 @@ class WebsiteFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 	/**
 	 * Generates the form fields from factory. Must be wrappend in an array.
 	 */
-	public function generate_fields() : array {
+	public function generate_fields(): array {
 		return [ $this->factory->field->create( $this->property_helper->values ) ];
 	}
 
@@ -70,7 +74,6 @@ class WebsiteFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 		return 'https://www.' . $this->property_helper->dummy->words( 1 ) . '.co.uk';
 	}
 
-
 	/**
 	 * The value as expected by Gravity Forms.
 	 */
@@ -80,10 +83,8 @@ class WebsiteFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 
 	/**
 	 * The GraphQL query string.
-	 *
-	 * @return string
 	 */
-	public function field_query() : string {
+	public function field_query(): string {
 		return '
 			... on WebsiteField {
 				adminLabel
@@ -122,7 +123,7 @@ class WebsiteFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 	/**
 	 * SubmitForm mutation string.
 	 */
-	public function submit_form_mutation() : string {
+	public function submit_form_mutation(): string {
 		return '
 			mutation ($formId: ID!, $fieldId: Int!, $value: String!, $draft: Boolean) {
 				submitGfForm( input: { id: $formId, saveAsDraft: $draft, fieldValues: {id: $fieldId, value: $value}}) {
@@ -153,7 +154,7 @@ class WebsiteFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 	/**
 	 * Returns the UpdateEntry mutation string.
 	 */
-	public function update_entry_mutation() : string {
+	public function update_entry_mutation(): string {
 		return '
 			mutation updateGfEntry( $entryId: ID!, $fieldId: Int!, $value: String! ){
 				updateGfEntry( input: { id: $entryId, shouldValidate: true, fieldValues: {id: $fieldId, value: $value} }) {
@@ -178,7 +179,7 @@ class WebsiteFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 	/**
 	 * Returns the UpdateDraftEntry mutation string.
 	 */
-	public function update_draft_entry_mutation() : string {
+	public function update_draft_entry_mutation(): string {
 		return '
 			mutation updateGfDraftEntry( $resumeToken: ID!, $fieldId: Int!, $value: String! ){
 				updateGfDraftEntry( input: { id: $resumeToken, idType: RESUME_TOKEN, fieldValues: {id: $fieldId, value: $value} } ) {
@@ -201,11 +202,9 @@ class WebsiteFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 	}
 
 	/**
-	 * The expected WPGraphQL field response.
-	 *
-	 * @param array $form the current form instance.
+	 * {@inheritDoc}
 	 */
-	public function expected_field_response( array $form ) : array {
+	public function expected_field_response( array $form ): array {
 		$expected   = $this->getExpectedFormFieldValues( $form['fields'][0] );
 		$expected[] = $this->expected_field_value( 'value', $this->field_value );
 
@@ -233,9 +232,8 @@ class WebsiteFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 	 *
 	 * @param string $mutationName .
 	 * @param mixed  $value .
-	 * @return array
 	 */
-	public function expected_mutation_response( string $mutationName, $value ) : array {
+	public function expected_mutation_response( string $mutationName, $value ): array {
 		return [
 			$this->expectedObject(
 				$mutationName,
@@ -267,7 +265,7 @@ class WebsiteFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 	 * @param array $actual_entry .
 	 * @param array $form .
 	 */
-	public function check_saved_values( $actual_entry, $form ) : void {
+	public function check_saved_values( $actual_entry, $form ): void {
 		$this->assertEquals( $this->field_value, $actual_entry[ $form['fields'][0]->id ], 'Submit mutation entry value not equal' );
 	}
 }

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'harness-software/wp-graphql-gravity-forms',
         'pretty_version' => 'dev-develop',
         'version' => 'dev-develop',
-        'reference' => '7b23b491eeec3889e5300440e9d4d48f71ecc61c',
+        'reference' => 'a7fed252b80aaaaf46d7ae61c7d923fd60f54da4',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'harness-software/wp-graphql-gravity-forms' => array(
             'pretty_version' => 'dev-develop',
             'version' => 'dev-develop',
-            'reference' => '7b23b491eeec3889e5300440e9d4d48f71ecc61c',
+            'reference' => 'a7fed252b80aaaaf46d7ae61c7d923fd60f54da4',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR adds traversable typehints to multiple parts of the codebase.

The PHP files in `tests` have also been linted with `phpcbf`.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

Code quality.

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
