### PR TITLE
feat!: Narrow `FormField.choices` and `.inputs` types to their implemations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - feat!: Refactor `FormsConnectionResolver` and `EntriesConnectionResolver` for compatibility with WPGraphQL v1.26.0 improvements.
+- feat!: Narrow `FormField.choices` and `FormField.inputs` field types to their implementations.
 - chore!: Bump minimum WPGraphQL version to v1.26.0.
 - chore!: Bump minimum WordPress version to v6.0.0.
 - chore!: Bump minimum Gravity Forms version to v2.7.0.

--- a/docs/querying-formfields.md
+++ b/docs/querying-formfields.md
@@ -144,6 +144,9 @@ As of v0.10.0, all `formFields` have access to the `value` GraphQL field, which 
           checkboxValues {
             inputId
             value
+            ... on CheckboxFieldChoice {
+              isSelected
+            }
           }
         }
         ... on NameField {

--- a/src/Registry/FieldChoiceRegistry.php
+++ b/src/Registry/FieldChoiceRegistry.php
@@ -18,6 +18,7 @@ use WPGraphQL\GF\Registry\TypeRegistry as GFTypeRegistry;
 use WPGraphQL\GF\Type\WPInterface\FieldChoice;
 use WPGraphQL\GF\Utils\Utils;
 
+
 /**
  * Class - FieldChoiceRegistry
  */
@@ -87,6 +88,9 @@ class FieldChoiceRegistry {
 
 					register_graphql_object_type( $choice_name, $config );
 				}
+
+				// Overload the field type with the new choice type.
+				Utils::overload_graphql_field_type( $field->graphql_single_name, 'choices', [ 'list_of' => $choice_name ] );
 
 				// Store in static array to prevent duplicate registration.
 				self::$registered_types[] = $choice_name;

--- a/src/Registry/FieldInputRegistry.php
+++ b/src/Registry/FieldInputRegistry.php
@@ -90,6 +90,8 @@ class FieldInputRegistry {
 					register_graphql_object_type( $input_name, $config );
 				}
 
+				Utils::overload_graphql_field_type( $field->graphql_single_name, 'inputs', [ 'list_of' => $input_name ] );
+
 				// Store in static array to prevent duplicate registration.
 				self::$registered_types[] = $input_name;
 			}

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -387,4 +387,30 @@ class Utils {
 
 		return absint( $id_parts['id'] );
 	}
+
+	/**
+	 * Overloads the field type of an existing GraphQL field.
+	 *
+	 * This is necessary because register_graphql_field() doesn't have a way to check inheritance.
+	 *
+	 * @see https://github.com/wp-graphql/wp-graphql/issues/3096
+	 *
+	 * @param string                      $object_type The WPGraphQL object type name where the field is located.
+	 * @param string                      $field_name  The field name to overload.
+	 * @param string|array<string|string> $new_type_name The new GraphQL type name to use.
+	 */
+	public static function overload_graphql_field_type( string $object_type, string $field_name, $new_type_name ): void {
+		add_filter(
+			'graphql_' . $object_type . '_fields',
+			static function ( array $fields ) use ( $field_name, $new_type_name ) {
+				if ( isset( $fields[ $field_name ] ) ) {
+					$fields[ $field_name ]['type'] = $new_type_name;
+				}
+
+				return $fields;
+			},
+			10,
+			1
+		);
+	}
 }

--- a/tests/wpunit/AddressFieldTest.php
+++ b/tests/wpunit/AddressFieldTest.php
@@ -134,17 +134,15 @@ class AddressFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 				errorMessage
 				hasAutocomplete
 				inputs {
-					... on AddressInputProperty {
-						customLabel
-						defaultValue
-						id
-						isHidden
-						key
-						label
-						name
-						placeholder
-						autocompleteAttribute
-					}
+					customLabel
+					defaultValue
+					id
+					isHidden
+					key
+					label
+					name
+					placeholder
+					autocompleteAttribute
 				}
 				isRequired
 				label

--- a/tests/wpunit/ChainedSelectFieldTest.php
+++ b/tests/wpunit/ChainedSelectFieldTest.php
@@ -138,25 +138,19 @@ class ChainedSelectFieldTest extends FormFieldTestCase implements FormFieldTestC
 				canPrepopulate
 				chainedSelectsAlignment
 				choices {
-					... on ChainedSelectFieldChoice {
+					choices {
 						choices {
-							... on ChainedSelectFieldChoice {
-								choices {
-									... on ChainedSelectFieldChoice {
-										isSelected
-										text
-										value
-									}
-								}
 								isSelected
 								text
 								value
 							}
-						}
 						isSelected
 						text
 						value
 					}
+					isSelected
+					text
+					value
 				}
 				conditionalLogic {
 					actionType
@@ -174,11 +168,9 @@ class ChainedSelectFieldTest extends FormFieldTestCase implements FormFieldTestC
 				hasChoiceValue
 				inputName
 				inputs {
-					... on ChainedSelectInputProperty {
-						label
-						id
-						name
-					}
+					label
+					id
+					name
 				}
 				isRequired
 				label

--- a/tests/wpunit/CheckboxFieldTest.php
+++ b/tests/wpunit/CheckboxFieldTest.php
@@ -210,11 +210,9 @@ class CheckboxFieldTest extends FormFieldTestCase implements FormFieldTestCaseIn
 					}
 				}
 				choices {
-					... on CheckboxFieldChoice {
-						isSelected
-						text
-						value
-					}
+					isSelected
+					text
+					value
 				}
 				conditionalLogic {
 					actionType
@@ -234,11 +232,9 @@ class CheckboxFieldTest extends FormFieldTestCase implements FormFieldTestCaseIn
 				hasSelectAll
 				inputName
 				inputs {
-					... on CheckboxInputProperty {
-						id
-						label
-						name
-					}
+					id
+					label
+					name
 				}
 				isRequired
 				label

--- a/tests/wpunit/DateFieldTest.php
+++ b/tests/wpunit/DateFieldTest.php
@@ -109,14 +109,12 @@ class DateFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 				errorMessage
 				inputName
 				inputs {
-					... on DateInputProperty {
-						autocompleteAttribute
-						customLabel
-						defaultValue
-						id
-						label
-						placeholder
-					}
+					autocompleteAttribute
+					customLabel
+					defaultValue
+					id
+					label
+					placeholder
 				}
 				isRequired
 				label

--- a/tests/wpunit/EmailFieldTest.php
+++ b/tests/wpunit/EmailFieldTest.php
@@ -128,15 +128,13 @@ class EmailFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 				hasAutocomplete
 				hasEmailConfirmation
 				inputs {
-					... on EmailInputProperty {
-						autocompleteAttribute
-						customLabel
-						defaultValue
-						id
-						label
-						name
-						placeholder
-					}
+					autocompleteAttribute
+					customLabel
+					defaultValue
+					id
+					label
+					name
+					placeholder
 				}
 				isRequired
 				label

--- a/tests/wpunit/MultiSelectFieldTest.php
+++ b/tests/wpunit/MultiSelectFieldTest.php
@@ -96,11 +96,9 @@ class MultiSelectFieldTest extends FormFieldTestCase implements FormFieldTestCas
 				adminLabel
 				canPrepopulate
 				choices {
-					... on MultiSelectFieldChoice {
 					isSelected
 					text
 					value
-					}
 				}
 				conditionalLogic {
 					actionType

--- a/tests/wpunit/NameFieldTest.php
+++ b/tests/wpunit/NameFieldTest.php
@@ -130,23 +130,21 @@ class NameFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 				hasAutocomplete
 				inputName
 				inputs {
-					... on NameInputProperty {
-						autocompleteAttribute
-						choices {
-							isSelected
-							text
-							value
-						}
-						customLabel
-						defaultValue
-						hasChoiceValue
-						id
-						isHidden
-						key
-						label
-						name
-						placeholder
+					autocompleteAttribute
+					choices {
+						isSelected
+						text
+						value
 					}
+					customLabel
+					defaultValue
+					hasChoiceValue
+					id
+					isHidden
+					key
+					label
+					name
+					placeholder
 				}
 				isRequired
 				labelPlacement

--- a/tests/wpunit/OptionCheckboxFieldTest.php
+++ b/tests/wpunit/OptionCheckboxFieldTest.php
@@ -271,13 +271,11 @@ class OptionCheckboxFieldTest extends FormFieldTestCase implements FormFieldTest
 				adminLabel
 				canPrepopulate
 				choices{
-					... on OptionFieldChoice {
-						formattedPrice
-						isSelected
-						price
-						text
-						value
-					}
+					formattedPrice
+					isSelected
+					price
+					text
+					value
 				}
 				cssClass
 				defaultValue
@@ -322,11 +320,9 @@ class OptionCheckboxFieldTest extends FormFieldTestCase implements FormFieldTest
 					}
 					hasSelectAll
 					inputs {
-						... on OptionCheckboxInputProperty {
-							id
-							label
-							name
-						}
+						id
+						label
+						name
 					}
 				}
 			}

--- a/tests/wpunit/OptionRadioFieldTest.php
+++ b/tests/wpunit/OptionRadioFieldTest.php
@@ -153,14 +153,12 @@ class OptionRadioFieldTest extends FormFieldTestCase implements FormFieldTestCas
 			... on OptionField {
 				adminLabel
 				canPrepopulate
-				choices{
-					... on OptionFieldChoice {
-						formattedPrice
-						isSelected
-						price
-						text
-						value
-					}
+				choices {
+					formattedPrice
+					isSelected
+					price
+					text
+					value
 				}
 				cssClass
 				defaultValue

--- a/tests/wpunit/OptionSelectFieldTest.php
+++ b/tests/wpunit/OptionSelectFieldTest.php
@@ -160,14 +160,12 @@ class OptionSelectFieldTest extends FormFieldTestCase implements FormFieldTestCa
 			... on OptionField {
 				adminLabel
 				canPrepopulate
-				choices{
-					... on OptionFieldChoice {
-						formattedPrice
-						isSelected
-						price
-						text
-						value
-					}
+				choices {
+					formattedPrice
+					isSelected
+					price
+					text
+					value
 				}
 				cssClass
 				defaultValue

--- a/tests/wpunit/PostCategoryCheckboxFieldTest.php
+++ b/tests/wpunit/PostCategoryCheckboxFieldTest.php
@@ -293,11 +293,9 @@ class PostCategoryCheckboxFieldTest extends FormFieldTestCase implements FormFie
 				adminLabel
 				canPrepopulate
 				choices {
-					... on PostCategoryFieldChoice {
-						isSelected
-						text
-						value
-					}
+					isSelected
+					text
+					value
 				}
 				conditionalLogic {
 					actionType
@@ -349,11 +347,9 @@ class PostCategoryCheckboxFieldTest extends FormFieldTestCase implements FormFie
 					}
 					hasSelectAll
 					inputs {
-						... on PostCategoryCheckboxInputProperty {
-							id
-							label
-							name
-						}
+						id
+						label
+						name
 					}
 				}
 			}

--- a/tests/wpunit/PostCategoryMultiSelectFieldTest.php
+++ b/tests/wpunit/PostCategoryMultiSelectFieldTest.php
@@ -161,11 +161,9 @@ class PostCategoryMultiSelectFieldTest extends FormFieldTestCase implements Form
 				adminLabel
 				canPrepopulate
 				choices {
-					... on PostCategoryFieldChoice {
-						isSelected
-						text
-						value
-					}
+					isSelected
+					text
+					value
 				}
 				conditionalLogic {
 					actionType

--- a/tests/wpunit/PostCategoryRadioFieldTest.php
+++ b/tests/wpunit/PostCategoryRadioFieldTest.php
@@ -149,11 +149,9 @@ class PostCategoryFieldRadioTest extends FormFieldTestCase implements FormFieldT
 				adminLabel
 				canPrepopulate
 				choices {
-					... on PostCategoryFieldChoice {
-						isSelected
-						text
-						value
-					}
+					isSelected
+					text
+					value
 				}
 				conditionalLogic {
 					actionType

--- a/tests/wpunit/PostCategorySelectFieldTest.php
+++ b/tests/wpunit/PostCategorySelectFieldTest.php
@@ -149,11 +149,9 @@ class PostCategoryFieldSelectTest extends FormFieldTestCase implements FormField
 				adminLabel
 				canPrepopulate
 				choices {
-					... on PostCategoryFieldChoice {
-						isSelected
-						text
-						value
-					}
+					isSelected
+					text
+					value
 				}
 				conditionalLogic {
 					actionType

--- a/tests/wpunit/PostTagsCheckboxFieldTest.php
+++ b/tests/wpunit/PostTagsCheckboxFieldTest.php
@@ -266,20 +266,16 @@ class PostTagsCheckboxFieldTest extends FormFieldTestCase implements FormFieldTe
 						value
 					}
 					choices {
-						... on PostTagsCheckboxFieldChoice {
-							isSelected
-							text
-							value
-						}
+						isSelected
+						text
+						value
 					}
 					hasChoiceValue
 					hasSelectAll
 					inputs {
-						... on PostTagsCheckboxInputProperty {
-							id
-							label
-							name
-						}
+						id
+						label
+						name
 					}
 				}
 			}

--- a/tests/wpunit/PostTagsMultiSelectFieldTest.php
+++ b/tests/wpunit/PostTagsMultiSelectFieldTest.php
@@ -191,11 +191,9 @@ class PostTagsMultiSelectFieldTest extends FormFieldTestCase implements FormFiel
 				size
 				... on PostTagsMultiSelectField {
 					choices {
-						... on PostTagsMultiSelectFieldChoice {
-							isSelected
-							text
-							value
-						}
+						isSelected
+						text
+						value
 					}
 					hasChoiceValue
 					hasEnhancedUI

--- a/tests/wpunit/PostTagsRadioFieldTest.php
+++ b/tests/wpunit/PostTagsRadioFieldTest.php
@@ -179,11 +179,9 @@ class PostTagsFieldRadioTest extends FormFieldTestCase implements FormFieldTestC
 				size
 				... on PostTagsRadioField {
 					choices {
-						... on PostTagsRadioFieldChoice {
-							isSelected
-							text
-							value
-						}
+						isSelected
+						text
+						value
 					}
 					hasChoiceValue
 					hasOtherChoice

--- a/tests/wpunit/ProductRadioFieldTest.php
+++ b/tests/wpunit/ProductRadioFieldTest.php
@@ -158,14 +158,12 @@ class ProductRadioFieldTest extends FormFieldTestCase implements FormFieldTestCa
 				visibility
 				... on ProductRadioField {
 					choices {
-						... on ProductRadioFieldChoice {
-							formattedPrice
-							isOtherChoice
-							isSelected
-							price
-							text
-							value
-						}
+						formattedPrice
+						isOtherChoice
+						isSelected
+						price
+						text
+						value
 					}
 					errorMessage
 					hasChoiceValue

--- a/tests/wpunit/ProductSelectFieldTest.php
+++ b/tests/wpunit/ProductSelectFieldTest.php
@@ -160,13 +160,11 @@ class ProductSelectFieldTest extends FormFieldTestCase implements FormFieldTestC
 				visibility
 				... on ProductSelectField {
 					choices {
-						... on ProductSelectFieldChoice {
-							formattedPrice
-							isSelected
-							price
-							text
-							value
-						}
+						formattedPrice
+						isSelected
+						price
+						text
+						value
 					}
 					errorMessage
 					hasAutocomplete

--- a/tests/wpunit/ProductSingleFieldTest.php
+++ b/tests/wpunit/ProductSingleFieldTest.php
@@ -160,11 +160,9 @@ class ProductSingleFieldTest extends FormFieldTestCase implements FormFieldTestC
 					formattedPrice
 					hasQuantity
 					inputs {
-						... on ProductSingleInputProperty {
-							id
-							label
-							name
-						}
+						id
+						label
+						name
 					}
 					isRequired
 					price

--- a/tests/wpunit/QuantitySelectFieldTest.php
+++ b/tests/wpunit/QuantitySelectFieldTest.php
@@ -205,13 +205,11 @@ class QuantitySelectFieldTest extends FormFieldTestCase implements FormFieldTest
 				... on QuantitySelectField {
 					autocompleteAttribute
 					choices {
-						... on QuantitySelectFieldChoice {
-							formattedPrice
-							isSelected
-							price
-							text
-							value
-						}
+						formattedPrice
+						isSelected
+						price
+						text
+						value
 					}
 					errorMessage
 					hasAutocomplete

--- a/tests/wpunit/QuizCheckboxFieldTest.php
+++ b/tests/wpunit/QuizCheckboxFieldTest.php
@@ -227,14 +227,12 @@ class QuizCheckboxFieldTest extends FormFieldTestCase implements FormFieldTestCa
 				answerExplanation
 				canPrepopulate
 				choices {
-					... on QuizCheckboxFieldChoice {
-						isCorrect
-						isOtherChoice
-						isSelected
-						text
-						value
-						weight
-					}
+					isCorrect
+					isOtherChoice
+					isSelected
+					text
+					value
+					weight
 				}
 				conditionalLogic{
 					actionType
@@ -270,11 +268,9 @@ class QuizCheckboxFieldTest extends FormFieldTestCase implements FormFieldTestCa
 					}
 					hasSelectAll
 					inputs {
-						... on QuizCheckboxInputProperty {
-							id
-							label
-							name
-						}
+						id
+						label
+						name
 					}
 				}
 			}

--- a/tests/wpunit/QuizRadioFieldTest.php
+++ b/tests/wpunit/QuizRadioFieldTest.php
@@ -145,14 +145,12 @@ class QuizRadioFieldTest extends FormFieldTestCase implements FormFieldTestCaseI
 				answerExplanation
 				canPrepopulate
 				choices {
-					... on QuizFieldChoice {
-						isCorrect
-						isOtherChoice
-						isSelected
-						text
-						value
-						weight
-					}
+					isCorrect
+					isOtherChoice
+					isSelected
+					text
+					value
+					weight
 				}
 				conditionalLogic{
 					actionType

--- a/tests/wpunit/QuizSelectFieldTest.php
+++ b/tests/wpunit/QuizSelectFieldTest.php
@@ -131,14 +131,12 @@ class QuizSelectFieldTest extends FormFieldTestCase implements FormFieldTestCase
 				answerExplanation
 				canPrepopulate
 				choices {
-					... on QuizSelectFieldChoice {
-						isCorrect
-						isOtherChoice
-						isSelected
-						text
-						value
-						weight
-					}
+					isCorrect
+					isOtherChoice
+					isSelected
+					text
+					value
+					weight
 				}
 				conditionalLogic{
 					actionType

--- a/tests/wpunit/RadioFieldTest.php
+++ b/tests/wpunit/RadioFieldTest.php
@@ -90,12 +90,10 @@ class RadioFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 				adminLabel
 				canPrepopulate
 				choices {
-					... on RadioFieldChoice {
-						isOtherChoice
-						isSelected
-						text
-						value
-					}
+					isOtherChoice
+					isSelected
+					text
+					value
 				}
 				conditionalLogic {
 					actionType

--- a/tests/wpunit/SelectFieldTest.php
+++ b/tests/wpunit/SelectFieldTest.php
@@ -92,11 +92,9 @@ class SelectFieldTest extends FormFieldTestCase implements FormFieldTestCaseInte
 				autocompleteAttribute
 				canPrepopulate
 				choices {
-					... on SelectFieldChoice {
-						isSelected
-						text
-						value
-					}
+					isSelected
+					text
+					value
 				}
 				conditionalLogic {
 					actionType

--- a/tests/wpunit/ShippingRadioFieldTest.php
+++ b/tests/wpunit/ShippingRadioFieldTest.php
@@ -143,14 +143,12 @@ class ShippingRadioFieldTest extends FormFieldTestCase implements FormFieldTestC
 				}
 				... on ShippingRadioField {
 					choices {
-						... on ShippingRadioFieldChoice {
-							formattedPrice
-							isOtherChoice
-							isSelected
-							price
-							text
-							value
-						}
+						formattedPrice
+						isOtherChoice
+						isSelected
+						price
+						text
+						value
 					}
 					errorMessage
 					hasChoiceValue

--- a/tests/wpunit/ShippingSelectFieldTest.php
+++ b/tests/wpunit/ShippingSelectFieldTest.php
@@ -146,13 +146,11 @@ class ShippingSelectFieldTest extends FormFieldTestCase implements FormFieldTest
 				... on ShippingSelectField {
 					autocompleteAttribute
 					choices {
-						... on ShippingSelectFieldChoice {
-							formattedPrice
-							isSelected
-							price
-							text
-							value
-						}
+						formattedPrice
+						isSelected
+						price
+						text
+						value
 					}
 					defaultValue
 					errorMessage

--- a/tests/wpunit/TimeFieldTest.php
+++ b/tests/wpunit/TimeFieldTest.php
@@ -122,14 +122,12 @@ class TimeFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 				descriptionPlacement
 				errorMessage
 				inputs {
-					... on TimeInputProperty {
-						autocompleteAttribute
-						customLabel
-						defaultValue
-						id
-						label
-						placeholder
-					}
+					autocompleteAttribute
+					customLabel
+					defaultValue
+					id
+					label
+					placeholder
 				}
 				isRequired
 				label

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -1,9 +1,9 @@
 <?php return array(
     'root' => array(
         'name' => 'harness-software/wp-graphql-gravity-forms',
-        'pretty_version' => 'dev-main',
-        'version' => 'dev-main',
-        'reference' => 'bf1bb216951852fa46841e279b738850f19b307e',
+        'pretty_version' => 'dev-develop',
+        'version' => 'dev-develop',
+        'reference' => '36e6e2a14091c4e14413f82bdf62dcf8c91d6815',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -11,9 +11,9 @@
     ),
     'versions' => array(
         'harness-software/wp-graphql-gravity-forms' => array(
-            'pretty_version' => 'dev-main',
-            'version' => 'dev-main',
-            'reference' => 'bf1bb216951852fa46841e279b738850f19b307e',
+            'pretty_version' => 'dev-develop',
+            'version' => 'dev-develop',
+            'reference' => '36e6e2a14091c4e14413f82bdf62dcf8c91d6815',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR updates the schema types for the `FormField.choices` and `FormField.inputs` fields to their respective implementing type, instead of the interface.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

```graphql
... on OptionField {
  adminLabel
  canPrepopulate
  choices {
  ... on OptionFieldChoice { # 👈 This is unnecessary and redundant. We **know** this b/c its on the OptionField
    formattedPrice
    isSelected
    price
    text
    value
  }
  
  # ✔️ Now we can query it directly on the `choice`
  formattedPrice
  isSelected
  price
  text
  value
}
```

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->
Uses the new `Utils::overload_graphql_field_type` to avoid [the validation issues in `graphql_register_field()`](https://github.com/wp-graphql/wp-graphql/issues/3096)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
