### PR TITLE
chore: use iterable type hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - feat!: Refactor `FormsConnectionResolver` and `EntriesConnectionResolver` for compatibility with WPGraphQL v1.26.0 improvements.
 - feat!: Narrow `FormField.choices` and `FormField.inputs` field types to their implementations.
 - dev: Use `FormFieldsDataLoader` to resolve fields instead of instantiating a new `Model`.
+- chore: Add iterable type hints.
 - chore!: Bump minimum WPGraphQL version to v1.26.0.
 - chore!: Bump minimum WordPress version to v6.0.0.
 - chore!: Bump minimum Gravity Forms version to v2.7.0.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -35,5 +35,4 @@ parameters:
 			- ../wp-gatsby/
 			- ../wp-jamstack-deployments/
 		ignoreErrors:
-			- identifier: missingType.iterableValue
 			- '#^Function gf_apply_filters(_ref_array)? invoked with ([1-9]|1[0-2]) parameters, 2 required\.$#'

--- a/src/Data/Connection/EntriesConnectionResolver.php
+++ b/src/Data/Connection/EntriesConnectionResolver.php
@@ -327,6 +327,8 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 	 * Correctly formats the field filters for search criteria.
 	 *
 	 * @param array<string,mixed>[] $field_filters The field filters.
+	 *
+	 * @return array{key?:string,operator:string,value:mixed}[]
 	 */
 	private function format_field_filters( array $field_filters ): array {
 		return array_reduce(

--- a/src/Data/Connection/EntriesConnectionResolver.php
+++ b/src/Data/Connection/EntriesConnectionResolver.php
@@ -179,11 +179,7 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Validates Model.
-	 *
-	 * @param mixed $model model.
-	 *
-	 * @return bool
+	 * {@inheritDoc}
 	 */
 	protected function is_valid_model( $model ) {
 		return ! empty( $model->databaseId ) || ! empty( $model->resumeToken );
@@ -394,7 +390,7 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 	 *
 	 * @param array<string,mixed> $field_filter Field filter.
 	 *
-	 * @return string[]
+	 * @return mixed[]
 	 */
 	private function get_field_filter_value_fields( array $field_filter ): array {
 		return array_values(

--- a/src/Data/Connection/FormsConnectionResolver.php
+++ b/src/Data/Connection/FormsConnectionResolver.php
@@ -41,14 +41,7 @@ class FormsConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Validates Model.
-	 *
-	 * If model isn't a class with a `fields` member, this function with have be overridden in
-	 * the Connection class.
-	 *
-	 * @param mixed $model model.
-	 *
-	 * @return bool
+	 * {@inheritDoc}
 	 */
 	protected function is_valid_model( $model ) {
 		return ! empty( $model->databaseId );

--- a/src/Data/EntryObjectMutation.php
+++ b/src/Data/EntryObjectMutation.php
@@ -94,12 +94,12 @@ class EntryObjectMutation {
 		 *
 		 * Useful for adding mutation support for custom fields.
 		 *
-		 * @param string              $field_value_input_class  The FieldValueInput class to use. The referenced class must extend AbstractFieldValueInput.
-		 * @param array               $args The GraphQL input args for the form field.
-		 * @param \GF_Field           $field The current Gravity Forms field object.
-		 * @param array<string,mixed> $form The current Gravity Forms form object.
-		 * @param array|null          $entry The current Gravity Forms entry object. Only available when using update (`gfUpdateEntry`, `gfUpdateDraftEntry`) mutations.
-		 * @param bool                $is_draft_mutation Whether the mutation is handling a Draft Entry (`gfUpdateDraftEntry`, or `gfSubmitForm` when `saveAsDraft` is `true`).
+		 * @param string                   $field_value_input_class  The FieldValueInput class to use. The referenced class must extend AbstractFieldValueInput.
+		 * @param array                    $args The GraphQL input args for the form field.
+		 * @param \GF_Field                $field The current Gravity Forms field object.
+		 * @param array<string,mixed>      $form The current Gravity Forms form object.
+		 * @param ?array<int|string,mixed> $entry The current Gravity Forms entry object. Only available when using update (`gfUpdateEntry`, `gfUpdateDraftEntry`) mutations.
+		 * @param bool                     $is_draft_mutation Whether the mutation is handling a Draft Entry (`gfUpdateDraftEntry`, or `gfSubmitForm` when `saveAsDraft` is `true`).
 		 */
 		$field_value_input = apply_filters( 'graphql_gf_field_value_input_class', $field_value_input, $args, $field, $form, $entry, $is_draft );
 

--- a/src/Data/FieldValueInput/AbstractFieldValueInput.php
+++ b/src/Data/FieldValueInput/AbstractFieldValueInput.php
@@ -21,7 +21,7 @@ abstract class AbstractFieldValueInput {
 	/**
 	 * The GraphQL field input args provided to the mutation.
 	 *
-	 * @var array|string
+	 * @var mixed[]|string
 	 */
 	protected $args;
 
@@ -70,7 +70,7 @@ abstract class AbstractFieldValueInput {
 	/**
 	 * The field value for submission.
 	 *
-	 * @var array|string
+	 * @var mixed[]|string
 	 */
 	public $value;
 
@@ -124,12 +124,12 @@ abstract class AbstractFieldValueInput {
 		/**
 		 * Filters the GraphQL input args for the field value input.
 		 *
-		 * @param array|string        $args              Field value input args.
-		 * @param \GF_Field           $field The current Gravity Forms field object.
-		 * @param array<string,mixed> $form The current  Gravity Forms form object.
-		 * @param array|null          $entry The current Gravity Forms entry object. Only available when using update (`gfUpdateEntry`, `gfUpdateDraftEntry`) mutations.
-		 * @param bool                $is_draft_mutation Whether the mutation is handling a Draft Entry (`gfUpdateDraftEntry`, or `gfSubmitForm` when `saveAsDraft` is `true`).
-		 * @param string              $field_name        The GraphQL input field name. E.g. `nameValues`.
+		 * @param array<string,mixed>|string $args              Field value input args.
+		 * @param \GF_Field                  $field             The current Gravity Forms field object.
+		 * @param array<string,mixed>        $form              The current  Gravity Forms form object.
+		 * @param ?array<int|string,mixed>   $entry             The current Gravity Forms entry object. Only available when using update (`gfUpdateEntry`, `gfUpdateDraftEntry`) mutations.
+		 * @param bool                       $is_draft_mutation Whether the mutation is handling a Draft Entry (`gfUpdateDraftEntry`, or `gfSubmitForm` when `saveAsDraft` is `true`).
+		 * @param string                     $field_name        The GraphQL input field name. E.g. `nameValues`.
 		 */
 		$this->args = apply_filters(
 			'graphql_gf_field_value_input_args',
@@ -144,13 +144,13 @@ abstract class AbstractFieldValueInput {
 		/**
 		 * Filters the prepared field value to be submitted to Gravity Forms.
 		 *
-		 * @param array|string        $prepared_field_value The field value formatted in a way Gravity Forms can understand.
-		 * @param array|string        $args                 Field value input args.
-		 * @param \GF_Field           $field                The current Gravity Forms field object.
-		 * @param array<string,mixed> $form                 The current Gravity Forms form object.
-		 * @param array|null          $entry                The current Gravity Forms entry object. Only available when using update (`gfUpdateEntry`, `gfUpdateDraftEntry`) mutations.
-		 * @param bool                $is_draft_mutation    Whether the mutation is handling a Draft Entry (`gfUpdateDraftEntry`, or `gfSubmitForm` when `saveAsDraft` is `true`).
-		 * @param string              $field_name           The GraphQL input field name. E.g. `nameValues`.
+		 * @param array|string               $prepared_field_value The field value formatted in a way Gravity Forms can understand.
+		 * @param array<string,mixed>|string $args                 Field value input args.
+		 * @param \GF_Field                  $field                The current Gravity Forms field object.
+		 * @param array<string,mixed>        $form                 The current Gravity Forms form object.
+		 * @param ?array<int|string,mixed>   $entry                The current Gravity Forms entry object. Only available when using update (`gfUpdateEntry`, `gfUpdateDraftEntry`) mutations.
+		 * @param bool                       $is_draft_mutation    Whether the mutation is handling a Draft Entry (`gfUpdateDraftEntry`, or `gfSubmitForm` when `saveAsDraft` is `true`).
+		 * @param string                     $field_name           The GraphQL input field name. E.g. `nameValues`.
 		 */
 		$this->value = apply_filters(
 			'graphql_gf_field_value_input_prepared_value',
@@ -189,7 +189,7 @@ abstract class AbstractFieldValueInput {
 	/**
 	 * Gets the input args for the specified field value input.
 	 *
-	 * @return string|array
+	 * @return string|mixed[]
 	 */
 	public function get_args() {
 		$key = $this->field_name;
@@ -200,7 +200,7 @@ abstract class AbstractFieldValueInput {
 	/**
 	 * Converts the field value args to a format GravityForms can understand.
 	 *
-	 * @return string|array the sanitized value.
+	 * @return string|mixed[] the sanitized value.
 	 */
 	protected function prepare_value() {
 		// You probably want to replace this.
@@ -210,7 +210,7 @@ abstract class AbstractFieldValueInput {
 	/**
 	 * Manually runs GF_Field::validate, and grabs any validation errors.
 	 *
-	 * @param array $errors .
+	 * @param array{id:int,message:string}[] $errors the array of validation errors.
 	 */
 	public function validate_value( array &$errors ): void {
 		$this->field->validate( $this->value, $this->form );
@@ -226,7 +226,7 @@ abstract class AbstractFieldValueInput {
 	/**
 	 * Adds the prepared value to the field values array for processing by Gravity Forms.
 	 *
-	 * @param array $field_values the existing field values array.
+	 * @param array<int|string,mixed> $field_values the existing field values array.
 	 */
 	public function add_value_to_submission( array &$field_values ): void {
 		$field_values[ $this->field->id ] = $this->value;

--- a/src/Data/FieldValueInput/AddressValuesInput.php
+++ b/src/Data/FieldValueInput/AddressValuesInput.php
@@ -17,14 +17,14 @@ class AddressValuesInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var array
+	 * @var array{street?:string,lineTwo?:string,city?:string,state?:string,zip?:string,country?:string}
 	 */
 	protected $args;
 
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var array
+	 * @var array<string,?string>
 	 */
 	public $value;
 
@@ -38,7 +38,7 @@ class AddressValuesInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @return array
+	 * @return array<int|string,?string>
 	 */
 	protected function prepare_value() {
 		$value = $this->args;

--- a/src/Data/FieldValueInput/CheckboxValuesInput.php
+++ b/src/Data/FieldValueInput/CheckboxValuesInput.php
@@ -20,14 +20,14 @@ class CheckboxValuesInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var array
+	 * @var array{inputId:float,value:string}[]
 	 */
 	protected $args;
 
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var array
+	 * @var array<string,string>
 	 */
 	public $value;
 
@@ -41,7 +41,7 @@ class CheckboxValuesInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @return array
+	 * @return array<string,string>
 	 *
 	 * @throws \GraphQL\Error\UserError .
 	 */
@@ -65,7 +65,7 @@ class CheckboxValuesInput extends AbstractFieldValueInput {
 						// translators: field ID, input ID.
 						esc_html__( 'Field %1$s has no input with an id of %2$s.', 'wp-graphql-gravity-forms' ),
 						esc_html( $this->field->id ),
-						esc_html( $single_value['inputId'] ),
+						esc_html( (string) $single_value['inputId'] ),
 					)
 				);
 			}

--- a/src/Data/FieldValueInput/ConsentValueInput.php
+++ b/src/Data/FieldValueInput/ConsentValueInput.php
@@ -26,7 +26,7 @@ class ConsentValueInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var array
+	 * @var array<string,mixed>
 	 */
 	public $value;
 
@@ -40,7 +40,7 @@ class ConsentValueInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @return array
+	 * @return array<int|string,mixed>
 	 */
 	protected function prepare_value() {
 		$field = $this->field;

--- a/src/Data/FieldValueInput/EmailValuesInput.php
+++ b/src/Data/FieldValueInput/EmailValuesInput.php
@@ -17,14 +17,14 @@ class EmailValuesInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var array
+	 * @var array{value?:string,confirmationValue?:string}
 	 */
 	protected $args;
 
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var array
+	 * @var array<int,?string>
 	 */
 	public $value;
 
@@ -38,7 +38,7 @@ class EmailValuesInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @return mixed[]
+	 * @return array<int,?string>
 	 */
 	protected function prepare_value() {
 		$value = $this->args;
@@ -46,7 +46,7 @@ class EmailValuesInput extends AbstractFieldValueInput {
 		$values_to_save   = [];
 		$values_to_save[] = $value['value'] ?? null;
 
-		if ( $this->field->emailConfirmEnabled ) {
+		if ( ! empty( $this->field->emailConfirmEnabled ) ) {
 			$values_to_save[] = $value['confirmationValue'] ?? null;
 		}
 
@@ -61,7 +61,7 @@ class EmailValuesInput extends AbstractFieldValueInput {
 		$field_values[ $this->field->id ] = $this->value[0];
 
 		// Confirmation values are stored in a subfield.
-		if ( isset( $this->value[1] ) ) {
+		if ( isset( $this->value[1] ) && isset( $this->field->inputs[1]['id'] ) ) {
 			$field_values[ $this->field->inputs[1]['id'] ] = $this->value[0];
 		}
 	}

--- a/src/Data/FieldValueInput/FileUploadValuesInput.php
+++ b/src/Data/FieldValueInput/FileUploadValuesInput.php
@@ -20,7 +20,7 @@ class FileUploadValuesInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var array
+	 * @var array{error:int,name:string,size:int,tmp_name:string,type:string}[]
 	 */
 	protected $args;
 
@@ -37,11 +37,8 @@ class FileUploadValuesInput extends AbstractFieldValueInput {
 	 * @return string|mixed
 	 *
 	 * @throws \GraphQL\Error\UserError
-	 *
-	 * @return string|mixed
 	 */
 	protected function prepare_value() {
-		// Draft entries don't upload files.
 		if ( $this->is_draft ) {
 			return '';
 		}
@@ -66,8 +63,6 @@ class FileUploadValuesInput extends AbstractFieldValueInput {
 
 	/**
 	 * {@inheritDoc}
-	 *
-	 * @param array $field_values.
 	 */
 	public function add_value_to_submission( array &$field_values ): void {
 		if ( empty( $this->entry ) || $this->is_draft || ! empty( $this->field->multipleFields ) ) {

--- a/src/Data/FieldValueInput/ImageValuesInput.php
+++ b/src/Data/FieldValueInput/ImageValuesInput.php
@@ -32,14 +32,14 @@ class ImageValuesInput extends FileUploadValuesInput {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var array
+	 * @var array<string,?string>
 	 */
 	public $value;
 
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @return array<string,mixed>
+	 * @return array<string,?string>
 	 *
 	 * @throws \GraphQL\Error\UserError
 	 */

--- a/src/Data/FieldValueInput/ListValuesInput.php
+++ b/src/Data/FieldValueInput/ListValuesInput.php
@@ -19,14 +19,14 @@ class ListValuesInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var array
+	 * @var array{rowValues:string[]}[]
 	 */
 	protected $args;
 
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var array
+	 * @var string[]|string
 	 */
 	public $value;
 
@@ -39,6 +39,8 @@ class ListValuesInput extends AbstractFieldValueInput {
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * @return string[]|string
 	 *
 	 * @throws \GraphQL\Error\UserError .
 	 */

--- a/src/Data/FieldValueInput/NameValuesInput.php
+++ b/src/Data/FieldValueInput/NameValuesInput.php
@@ -17,14 +17,14 @@ class NameValuesInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var array
+	 * @var array{prefix?:string,first?:string,middle?:string,last?:string,suffix?:string}
 	 */
 	protected $args;
 
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var array
+	 * @var array<string,?string>
 	 */
 	public $value;
 
@@ -38,7 +38,7 @@ class NameValuesInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @return array
+	 * @return array<int|string,?string>
 	 */
 	protected function prepare_value() {
 		$value = $this->args;

--- a/src/Data/FieldValueInput/ProductValueInput.php
+++ b/src/Data/FieldValueInput/ProductValueInput.php
@@ -20,14 +20,14 @@ class ProductValueInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var array
+	 * @var array{quantity:?float,price:?float}
 	 */
 	protected $args;
 
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var array
+	 * @var array<string,mixed>
 	 */
 	public $value;
 
@@ -83,7 +83,7 @@ class ProductValueInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @return array
+	 * @return array{quantity:?float,price:?float}
 	 */
 	public function get_args() {
 		return $this->input_args[ $this->field_name ] ?? [

--- a/src/Data/FieldValueInput/ValueInput.php
+++ b/src/Data/FieldValueInput/ValueInput.php
@@ -31,6 +31,8 @@ class ValueInput extends AbstractFieldValueInput {
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * @return string
 	 */
 	protected function prepare_value() {
 		// Handle choices with price.
@@ -44,7 +46,7 @@ class ValueInput extends AbstractFieldValueInput {
 
 		if ( 'total' === $this->field->type ) {
 			// Convert to number so draft updates dont return the currency.
-			return GFCommon::to_number( $this->args );
+			return (string) GFCommon::to_number( $this->args );
 		}
 
 		return $this->args;

--- a/src/Mutation/UpdateEntry.php
+++ b/src/Mutation/UpdateEntry.php
@@ -39,7 +39,7 @@ class UpdateEntry extends AbstractMutation {
 	/**
 	 * Gravity Forms field validation errors.
 	 *
-	 * @var array
+	 * @var array{id:int,message:string}[]
 	 */
 	protected static array $errors = [];
 
@@ -253,6 +253,8 @@ class UpdateEntry extends AbstractMutation {
 	 * @param array<int|string,mixed> $entry The entry array.
 	 * @param array<string,mixed>     $form The form array.
 	 * @param bool                    $should_validate .
+	 *
+	 * @return array<int|string,mixed> The prepared field values.
 	 */
 	private static function prepare_field_values( array $field_values, array $entry, array $form, bool $should_validate ): array {
 		$formatted_values = [];
@@ -273,9 +275,11 @@ class UpdateEntry extends AbstractMutation {
 	/**
 	 * Prepares field values before saving it to the entry.
 	 *
-	 * @param array                   $values the entry values.
+	 * @param array<int|string,mixed> $values the field values.
 	 * @param array<int|string,mixed> $entry the existing entry.
 	 * @param array<string,mixed>     $form The form array.
+	 *
+	 * @return array<int|string,mixed> The prepared values.
 	 */
 	public static function prepare_field_values_for_save( array $values, array $entry, array $form ): array {
 		// We need the entry fresh to prepare the values.
@@ -315,6 +319,8 @@ class UpdateEntry extends AbstractMutation {
 	 * @param array<string,mixed>     $post_data .
 	 * @param array<string,mixed>     $form The form array.
 	 * @param array<int|string,mixed> $entry .
+	 *
+	 * @return array<string,mixed> The post data.
 	 */
 	public static function set_post_id_for_update( array $post_data, array $form, array $entry ): array {
 		$post_data['ID'] = $entry['post_id'];

--- a/src/Registry/FieldChoiceRegistry.php
+++ b/src/Registry/FieldChoiceRegistry.php
@@ -105,7 +105,7 @@ class FieldChoiceRegistry {
 	 * @param \GF_Field $field The Gravity Forms field object.
 	 * @param string[]  $settings The Gravity Forms field settings.
 	 *
-	 * @return array<string,mixed>
+	 * @return array{description:string,interfaces:string[],fields:array<string,array<string,mixed>>,eagerlyLoadType:bool}
 	 */
 	public static function get_config_from_settings( string $choice_name, GF_Field $field, array $settings ): array {
 		$interfaces = self::get_interfaces( $settings );

--- a/src/Registry/FieldInputRegistry.php
+++ b/src/Registry/FieldInputRegistry.php
@@ -105,7 +105,7 @@ class FieldInputRegistry {
 	 * @param \GF_Field $field The Gravity Forms field object.
 	 * @param string[]  $settings The Gravity Forms field settings.
 	 *
-	 * @return array<string,mixed>
+	 * @return array{description:string,interfaces:string[],fields:array<string,array<string,mixed>>,eagerlyLoadType:bool}
 	 */
 	public static function get_config_from_settings( string $input_name, GF_Field $field, array $settings ): array {
 		$interfaces = self::get_interfaces( $settings );

--- a/src/Utils/GFUtils.php
+++ b/src/Utils/GFUtils.php
@@ -301,9 +301,9 @@ class GFUtils {
 	 *
 	 * @param array<string,mixed>     $form .
 	 * @param array<int|string,mixed> $entry .
-	 * @param array                   $field_values .
+	 * @param ?array<string,mixed>    $field_values .
 	 * @param int                     $page_number .
-	 * @param array                   $files .
+	 * @param mixed[]                 $files .
 	 * @param string                  $form_unique_id .
 	 * @param string                  $ip .
 	 * @param string                  $source_url .
@@ -343,11 +343,11 @@ class GFUtils {
 	 *
 	 * @see https://docs.gravityforms.com/api-functions/#submit-form
 	 *
-	 * @param int   $form_id .
-	 * @param array $input_values .
-	 * @param array $field_values .
-	 * @param int   $target_page .
-	 * @param int   $source_page .
+	 * @param int                 $form_id .
+	 * @param array<string,mixed> $input_values .
+	 * @param array<string,mixed> $field_values .
+	 * @param int                 $target_page .
+	 * @param int                 $source_page .
 	 *
 	 * @return array<int|string,mixed> The submission object.
 	 *

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'harness-software/wp-graphql-gravity-forms',
         'pretty_version' => 'dev-develop',
         'version' => 'dev-develop',
-        'reference' => 'de8beb6206951e8ffffc7954ac3dc3af4bb3cbf1',
+        'reference' => '5cff081a7cf4dd60ac43574c2167720f0317e0f7',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'harness-software/wp-graphql-gravity-forms' => array(
             'pretty_version' => 'dev-develop',
             'version' => 'dev-develop',
-            'reference' => 'de8beb6206951e8ffffc7954ac3dc3af4bb3cbf1',
+            'reference' => '5cff081a7cf4dd60ac43574c2167720f0317e0f7',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
This PR adds iterable typehints whereever possible to doc-blocks, and restores the sniff to PHPStan

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
Code quality.



## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
