### PR TITLE
fix: Check for url before passing it to `url_to_postid()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - feat!: Narrow `FormField.choices` and `FormField.inputs` field types to their implementations.
 - fix!: Keep `PageField` with previous page data when filtering `formFields` by `pageNumber`. H/t @SamuelHadsall .
 - fix: Handle RadioField submission values when using a custom "other" choice. H/t @Gytjarek .
+- fix: Check for Submission Confirmation url before attempting to get the associated post ID.
 - dev: Use `FormFieldsDataLoader` to resolve fields instead of instantiating a new `Model`.
 - chore: Add iterable type hints.
 - chore!: Bump minimum WPGraphQL version to v1.26.0.

--- a/src/Type/WPObject/SubmissionConfirmation.php
+++ b/src/Type/WPObject/SubmissionConfirmation.php
@@ -50,7 +50,11 @@ class SubmissionConfirmation extends AbstractObject implements TypeWithConnectio
 				'toType'   => 'Page',
 				'oneToOne' => true,
 				'resolve'  => static function ( $source, array $args, AppContext $context, ResolveInfo $info ) {
-					$page_id = url_to_postid( $source['url'] ); //phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.url_to_postid_url_to_postid
+					$page_id = isset( $source['url'] ) ? url_to_postid( $source['url'] ) : null; //phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.url_to_postid_url_to_postid
+
+					if ( empty( $page_id ) ) {
+						return null;
+					}
 
 					$resolver = new PostObjectConnectionResolver( $source, $args, $context, $info, 'page' );
 
@@ -90,7 +94,7 @@ class SubmissionConfirmation extends AbstractObject implements TypeWithConnectio
 				'type'        => 'Int',
 				'description' => __( 'Contains the Id of the WordPress page that the browser will be redirected to. Only applicable when type is set to `PAGE`.', 'wp-graphql-gravity-forms' ),
 				'resolve'     => static function ( $source ) {
-					$post_id = url_to_postid( $source['url'] ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.url_to_postid_url_to_postid
+					$post_id = isset( $source['url'] ) ? url_to_postid( $source['url'] ) : null; // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.url_to_postid_url_to_postid
 
 					return ! empty( $post_id ) ? $post_id : null;
 				},


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR fixes several PHP notices when fetching `SubmissionConfirmation.page` or `SubmissionConfirmation.pageId` when there is no associated URL.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->
Check there's a valid url, before passing it to `url_to_postid()`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
