### PR TITLE
feat: Add `FieldError.connectedFormField` connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - fix!: Keep `PageField` with previous page data when filtering `formFields` by `pageNumber`. H/t @SamuelHadsall .
 - fix: Handle RadioField submission values when using a custom "other" choice. H/t @Gytjarek .
 - fix: Check for Submission Confirmation url before attempting to get the associated post ID.
+- feat: Add `FieldError.connectedFormField` connection to `FieldError` type.
 - dev: Use `FormFieldsDataLoader` to resolve fields instead of instantiating a new `Model`.
 - chore: Add iterable type hints.
 - chore!: Bump minimum WPGraphQL version to v1.26.0.

--- a/docs/submitting-forms.md
+++ b/docs/submitting-forms.md
@@ -121,8 +121,12 @@ The `fieldValues` input takes an array of objects containing the `id` of the fie
       url     # The redirect URL - if the confirmation type is a "REDIRECT".
     }
     errors {
-      id # The field that failed validation.
+      id # The field ID that failed validation.
       message
+      connectedFormField { # The full FormField object if you need more info.
+        database
+        type
+      }
     }
     entry {
       # See docs on querying Entries.
@@ -150,7 +154,11 @@ If the field is NOT updated successfully, such as when a field validation error 
 "errors": [
   {
     "id": "1",
-    "message": "The text entered exceeds the maximum number of characters."
+    "message": "The text entered exceeds the maximum number of characters.",
+    "connectedFormField": {
+      "database": 1,
+      "type": "TEXT"
+    }
   }
 ]
 ```

--- a/docs/updating-entries.md
+++ b/docs/updating-entries.md
@@ -27,8 +27,12 @@ You can update a [Gravity Forms entry](https://docs.gravityforms.com/entry-objec
     }
   ) {
     errors {
-      id # The field that failed validation.
+      id # The field ID that failed validation.
       message
+      connectedFormField { # The full FormField object if you need more info.
+        id
+        type
+      }
     }
     entry {
       # See above section on querying Entries.

--- a/src/Data/EntryObjectMutation.php
+++ b/src/Data/EntryObjectMutation.php
@@ -116,6 +116,7 @@ class EntryObjectMutation {
 	 * Generates array of field errors from the submission.
 	 *
 	 * @param array<int|string,string> $messages The Gravity Forms submission validation messages.
+	 * @param int                      $form_id  The ID of the form.
 	 *
 	 * @return array{message:string,id:int|string}[]
 	 */

--- a/src/Data/EntryObjectMutation.php
+++ b/src/Data/EntryObjectMutation.php
@@ -119,12 +119,13 @@ class EntryObjectMutation {
 	 *
 	 * @return array{message:string,id:int|string}[]
 	 */
-	public static function get_submission_errors( array $messages ): array {
+	public static function get_submission_errors( array $messages, int $form_id ): array {
 		return array_map(
-			static function ( $id, $message ): array {
+			static function ( $id, $message ) use ( $form_id ): array {
 				return [
 					'id'      => $id,
 					'message' => $message,
+					'formId'  => $form_id,
 				];
 			},
 			array_keys( $messages ),

--- a/src/Mutation/SubmitDraftEntry.php
+++ b/src/Mutation/SubmitDraftEntry.php
@@ -106,7 +106,7 @@ class SubmitDraftEntry extends AbstractMutation {
 			return [
 				'confirmation' => isset( $result['confirmation_type'] ) ? EntryObjectMutation::get_submission_confirmation( $result ) : null,
 				'entryId'      => ! empty( $result['entry_id'] ) ? absint( $result['entry_id'] ) : null,
-				'errors'       => isset( $result['validation_messages'] ) ? EntryObjectMutation::get_submission_errors( $result['validation_messages'] ) : null,
+				'errors'       => isset( $result['validation_messages'] ) ? EntryObjectMutation::get_submission_errors( $result['validation_messages'], (int) $form['id'] ) : null,
 			];
 		};
 	}

--- a/src/Mutation/SubmitForm.php
+++ b/src/Mutation/SubmitForm.php
@@ -165,7 +165,7 @@ class SubmitForm extends AbstractMutation {
 			return [
 				'confirmation' => isset( $submission['confirmation_type'] ) ? EntryObjectMutation::get_submission_confirmation( $submission ) : null,
 				'entryId'      => ! empty( $submission['entry_id'] ) ? absint( $submission['entry_id'] ) : null,
-				'errors'       => isset( $submission['validation_messages'] ) ? EntryObjectMutation::get_submission_errors( $submission['validation_messages'] ) : null,
+				'errors'       => isset( $submission['validation_messages'] ) ? EntryObjectMutation::get_submission_errors( $submission['validation_messages'], $form_id ) : null,
 				'resumeToken'  => $submission['resume_token'] ?? null,
 				'resumeUrl'    => isset( $submission['resume_token'] ) ? GFUtils::get_resume_url( $submission['resume_token'], $entry_data['source_url'] ?? '', $form ) : null,
 				'submission'   => $submission,

--- a/src/Type/WPObject/FieldError.php
+++ b/src/Type/WPObject/FieldError.php
@@ -11,6 +11,9 @@ declare( strict_types = 1 );
 
 namespace WPGraphQL\GF\Type\WPObject;
 
+use WPGraphQL\AppContext;
+use WPGraphQL\GF\Data\Loader\FormFieldsLoader;
+use WPGraphQL\GF\Type\WPInterface\FormField;
 use WPGraphQL\GF\Type\WPObject\AbstractObject;
 
 /**
@@ -36,13 +39,26 @@ class FieldError extends AbstractObject {
 	 */
 	public static function get_fields(): array {
 		return [
-			'id'      => [
+			'id'                 => [
 				'type'        => 'Float',
 				'description' => __( 'The field with the associated error message.', 'wp-graphql-gravity-forms' ),
 			],
-			'message' => [
+			'message'            => [
 				'type'        => 'String',
 				'description' => __( 'Error message.', 'wp-graphql-gravity-forms' ),
+			],
+			'connectedFormField' => [
+				'type'        => FormField::$type,
+				'description' => __( 'The form field that the error is connected to.', 'wp-graphql-gravity-forms' ),
+				'resolve'     => static function ( $source, array $args, AppContext $context ) {
+					if ( ! isset( $source['id'] ) || ! isset( $source['formId'] ) ) {
+						return null;
+					}
+
+					$id_for_loader = (string) $source['formId'] . ':' . (string) $source['id'];
+
+					return $context->get_loader( FormFieldsLoader::$name )->load_deferred( $id_for_loader );
+				},
 			],
 		];
 	}

--- a/tests/wpunit/AddressFieldTest.php
+++ b/tests/wpunit/AddressFieldTest.php
@@ -177,6 +177,10 @@ class AddressFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -215,6 +219,10 @@ class AddressFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -247,6 +255,10 @@ class AddressFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/CaptchaFieldTest.php
+++ b/tests/wpunit/CaptchaFieldTest.php
@@ -182,6 +182,10 @@ class CaptchaFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields(where:{fieldTypes:TEXT}) {
@@ -213,6 +217,10 @@ class CaptchaFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -238,6 +246,10 @@ class CaptchaFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields (where:{fieldTypes:TEXT}){

--- a/tests/wpunit/ChainedSelectFieldTest.php
+++ b/tests/wpunit/ChainedSelectFieldTest.php
@@ -198,6 +198,10 @@ class ChainedSelectFieldTest extends FormFieldTestCase implements FormFieldTestC
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -229,6 +233,10 @@ class ChainedSelectFieldTest extends FormFieldTestCase implements FormFieldTestC
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -254,6 +262,10 @@ class ChainedSelectFieldTest extends FormFieldTestCase implements FormFieldTestC
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/CheckboxFieldTest.php
+++ b/tests/wpunit/CheckboxFieldTest.php
@@ -258,6 +258,10 @@ class CheckboxFieldTest extends FormFieldTestCase implements FormFieldTestCaseIn
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -307,6 +311,10 @@ class CheckboxFieldTest extends FormFieldTestCase implements FormFieldTestCaseIn
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -336,6 +344,10 @@ class CheckboxFieldTest extends FormFieldTestCase implements FormFieldTestCaseIn
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/ConsentFieldTest.php
+++ b/tests/wpunit/ConsentFieldTest.php
@@ -152,6 +152,10 @@ class ConsentFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -183,6 +187,10 @@ class ConsentFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -208,6 +216,10 @@ class ConsentFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/DateFieldTest.php
+++ b/tests/wpunit/DateFieldTest.php
@@ -142,6 +142,10 @@ class DateFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -173,6 +177,10 @@ class DateFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -198,6 +206,10 @@ class DateFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/EmailFieldTest.php
+++ b/tests/wpunit/EmailFieldTest.php
@@ -186,6 +186,10 @@ class EmailFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -217,6 +221,10 @@ class EmailFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -242,6 +250,10 @@ class EmailFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/EmailFieldWithConfirmationTest.php
+++ b/tests/wpunit/EmailFieldWithConfirmationTest.php
@@ -191,6 +191,10 @@ class EmailFieldWithConfirmationTest extends FormFieldTestCase implements FormFi
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -222,6 +226,10 @@ class EmailFieldWithConfirmationTest extends FormFieldTestCase implements FormFi
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -247,6 +255,10 @@ class EmailFieldWithConfirmationTest extends FormFieldTestCase implements FormFi
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/FileUploadFieldTest.php
+++ b/tests/wpunit/FileUploadFieldTest.php
@@ -235,6 +235,10 @@ class FileUploadFieldTest extends FormFieldTestCase implements FormFieldTestCase
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -270,6 +274,10 @@ class FileUploadFieldTest extends FormFieldTestCase implements FormFieldTestCase
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -299,6 +307,10 @@ class FileUploadFieldTest extends FormFieldTestCase implements FormFieldTestCase
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/FileUploadMultipleFieldTest.php
+++ b/tests/wpunit/FileUploadMultipleFieldTest.php
@@ -246,6 +246,10 @@ class FileUploadMultipleFieldTest extends FormFieldTestCase implements FormField
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -281,6 +285,10 @@ class FileUploadMultipleFieldTest extends FormFieldTestCase implements FormField
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -310,6 +318,10 @@ class FileUploadMultipleFieldTest extends FormFieldTestCase implements FormField
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/FormFieldConnectionPageFilterTest.php
+++ b/tests/wpunit/FormFieldConnectionPageFilterTest.php
@@ -135,8 +135,6 @@ class FormFieldConnectionPageFilterTest extends GFGraphQLTestCase {
 		$form     = GFAPI::get_form( $this->form_id );
 		$wp_query = $form['fields'];
 
-		error_log( print_r( $wp_query, true ) );
-
 		/**
 		 * Test with empty offset.
 		 */

--- a/tests/wpunit/HiddenFieldTest.php
+++ b/tests/wpunit/HiddenFieldTest.php
@@ -112,6 +112,10 @@ class HiddenFieldTest extends FormFieldTestCase implements FormFieldTestCaseInte
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -143,6 +147,10 @@ class HiddenFieldTest extends FormFieldTestCase implements FormFieldTestCaseInte
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -169,6 +177,10 @@ class HiddenFieldTest extends FormFieldTestCase implements FormFieldTestCaseInte
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/ListFieldColumnsTest.php
+++ b/tests/wpunit/ListFieldColumnsTest.php
@@ -208,6 +208,10 @@ class ListFieldColumnsTest extends FormFieldTestCase implements FormFieldTestCas
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -241,6 +245,10 @@ class ListFieldColumnsTest extends FormFieldTestCase implements FormFieldTestCas
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -268,6 +276,10 @@ class ListFieldColumnsTest extends FormFieldTestCase implements FormFieldTestCas
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/ListFieldTest.php
+++ b/tests/wpunit/ListFieldTest.php
@@ -168,6 +168,10 @@ class ListFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -201,6 +205,10 @@ class ListFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -228,6 +236,10 @@ class ListFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/MultiSelectFieldTest.php
+++ b/tests/wpunit/MultiSelectFieldTest.php
@@ -140,6 +140,10 @@ class MultiSelectFieldTest extends FormFieldTestCase implements FormFieldTestCas
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -171,6 +175,10 @@ class MultiSelectFieldTest extends FormFieldTestCase implements FormFieldTestCas
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -196,6 +204,10 @@ class MultiSelectFieldTest extends FormFieldTestCase implements FormFieldTestCas
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/NameFieldTest.php
+++ b/tests/wpunit/NameFieldTest.php
@@ -176,6 +176,10 @@ class NameFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -213,6 +217,10 @@ class NameFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -244,6 +252,10 @@ class NameFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/NumberFieldTest.php
+++ b/tests/wpunit/NumberFieldTest.php
@@ -139,6 +139,10 @@ class NumberFieldTest extends FormFieldTestCase implements FormFieldTestCaseInte
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -170,6 +174,10 @@ class NumberFieldTest extends FormFieldTestCase implements FormFieldTestCaseInte
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -195,6 +203,10 @@ class NumberFieldTest extends FormFieldTestCase implements FormFieldTestCaseInte
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/OptionCheckboxFieldTest.php
+++ b/tests/wpunit/OptionCheckboxFieldTest.php
@@ -339,6 +339,10 @@ class OptionCheckboxFieldTest extends FormFieldTestCase implements FormFieldTest
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -390,6 +394,10 @@ class OptionCheckboxFieldTest extends FormFieldTestCase implements FormFieldTest
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -420,6 +428,10 @@ class OptionCheckboxFieldTest extends FormFieldTestCase implements FormFieldTest
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/OptionRadioFieldTest.php
+++ b/tests/wpunit/OptionRadioFieldTest.php
@@ -198,6 +198,10 @@ class OptionRadioFieldTest extends FormFieldTestCase implements FormFieldTestCas
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -229,6 +233,10 @@ class OptionRadioFieldTest extends FormFieldTestCase implements FormFieldTestCas
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -255,6 +263,10 @@ class OptionRadioFieldTest extends FormFieldTestCase implements FormFieldTestCas
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/OptionSelectFieldTest.php
+++ b/tests/wpunit/OptionSelectFieldTest.php
@@ -208,6 +208,10 @@ class OptionSelectFieldTest extends FormFieldTestCase implements FormFieldTestCa
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -239,6 +243,10 @@ class OptionSelectFieldTest extends FormFieldTestCase implements FormFieldTestCa
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -265,6 +273,10 @@ class OptionSelectFieldTest extends FormFieldTestCase implements FormFieldTestCa
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/PhoneFieldTest.php
+++ b/tests/wpunit/PhoneFieldTest.php
@@ -134,6 +134,10 @@ class PhoneFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -165,6 +169,10 @@ class PhoneFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -190,6 +198,10 @@ class PhoneFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/PostCategoryCheckboxFieldTest.php
+++ b/tests/wpunit/PostCategoryCheckboxFieldTest.php
@@ -366,6 +366,10 @@ class PostCategoryCheckboxFieldTest extends FormFieldTestCase implements FormFie
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -415,6 +419,10 @@ class PostCategoryCheckboxFieldTest extends FormFieldTestCase implements FormFie
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -444,6 +452,10 @@ class PostCategoryCheckboxFieldTest extends FormFieldTestCase implements FormFie
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/PostCategoryMultiSelectFieldTest.php
+++ b/tests/wpunit/PostCategoryMultiSelectFieldTest.php
@@ -210,6 +210,10 @@ class PostCategoryMultiSelectFieldTest extends FormFieldTestCase implements Form
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -241,6 +245,10 @@ class PostCategoryMultiSelectFieldTest extends FormFieldTestCase implements Form
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -266,6 +274,10 @@ class PostCategoryMultiSelectFieldTest extends FormFieldTestCase implements Form
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/PostCategoryRadioFieldTest.php
+++ b/tests/wpunit/PostCategoryRadioFieldTest.php
@@ -200,6 +200,10 @@ class PostCategoryFieldRadioTest extends FormFieldTestCase implements FormFieldT
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -231,6 +235,10 @@ class PostCategoryFieldRadioTest extends FormFieldTestCase implements FormFieldT
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -256,6 +264,10 @@ class PostCategoryFieldRadioTest extends FormFieldTestCase implements FormFieldT
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/PostCategorySelectFieldTest.php
+++ b/tests/wpunit/PostCategorySelectFieldTest.php
@@ -203,6 +203,10 @@ class PostCategoryFieldSelectTest extends FormFieldTestCase implements FormField
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -234,6 +238,10 @@ class PostCategoryFieldSelectTest extends FormFieldTestCase implements FormField
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -259,6 +267,10 @@ class PostCategoryFieldSelectTest extends FormFieldTestCase implements FormField
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/PostContentFieldTest.php
+++ b/tests/wpunit/PostContentFieldTest.php
@@ -132,6 +132,10 @@ class PostContentFieldTest extends FormFieldTestCase implements FormFieldTestCas
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -163,6 +167,10 @@ class PostContentFieldTest extends FormFieldTestCase implements FormFieldTestCas
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -188,6 +196,10 @@ class PostContentFieldTest extends FormFieldTestCase implements FormFieldTestCas
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/PostExcerptFieldTest.php
+++ b/tests/wpunit/PostExcerptFieldTest.php
@@ -130,6 +130,10 @@ class PostExcerptFieldTest extends FormFieldTestCase implements FormFieldTestCas
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -161,6 +165,10 @@ class PostExcerptFieldTest extends FormFieldTestCase implements FormFieldTestCas
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -186,6 +194,10 @@ class PostExcerptFieldTest extends FormFieldTestCase implements FormFieldTestCas
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/PostImageFieldTest.php
+++ b/tests/wpunit/PostImageFieldTest.php
@@ -271,6 +271,10 @@ class PostImageFieldTest extends FormFieldTestCase implements FormFieldTestCaseI
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -309,6 +313,10 @@ class PostImageFieldTest extends FormFieldTestCase implements FormFieldTestCaseI
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -341,6 +349,10 @@ class PostImageFieldTest extends FormFieldTestCase implements FormFieldTestCaseI
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/PostTagsCheckboxFieldTest.php
+++ b/tests/wpunit/PostTagsCheckboxFieldTest.php
@@ -292,6 +292,10 @@ class PostTagsCheckboxFieldTest extends FormFieldTestCase implements FormFieldTe
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -327,6 +331,10 @@ class PostTagsCheckboxFieldTest extends FormFieldTestCase implements FormFieldTe
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -356,6 +364,10 @@ class PostTagsCheckboxFieldTest extends FormFieldTestCase implements FormFieldTe
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/PostTagsMultiSelectFieldTest.php
+++ b/tests/wpunit/PostTagsMultiSelectFieldTest.php
@@ -212,6 +212,10 @@ class PostTagsMultiSelectFieldTest extends FormFieldTestCase implements FormFiel
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -243,6 +247,10 @@ class PostTagsMultiSelectFieldTest extends FormFieldTestCase implements FormFiel
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -268,6 +276,10 @@ class PostTagsMultiSelectFieldTest extends FormFieldTestCase implements FormFiel
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/PostTagsRadioFieldTest.php
+++ b/tests/wpunit/PostTagsRadioFieldTest.php
@@ -202,6 +202,10 @@ class PostTagsFieldRadioTest extends FormFieldTestCase implements FormFieldTestC
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -233,6 +237,10 @@ class PostTagsFieldRadioTest extends FormFieldTestCase implements FormFieldTestC
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -258,6 +266,10 @@ class PostTagsFieldRadioTest extends FormFieldTestCase implements FormFieldTestC
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/PostTagsTextFieldTest.php
+++ b/tests/wpunit/PostTagsTextFieldTest.php
@@ -168,6 +168,10 @@ class PostTagsTextFieldTest extends FormFieldTestCase implements FormFieldTestCa
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -199,6 +203,10 @@ class PostTagsTextFieldTest extends FormFieldTestCase implements FormFieldTestCa
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -224,6 +232,10 @@ class PostTagsTextFieldTest extends FormFieldTestCase implements FormFieldTestCa
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/PostTitleFieldTest.php
+++ b/tests/wpunit/PostTitleFieldTest.php
@@ -130,6 +130,10 @@ class PostTitleFieldTest extends FormFieldTestCase implements FormFieldTestCaseI
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -161,6 +165,10 @@ class PostTitleFieldTest extends FormFieldTestCase implements FormFieldTestCaseI
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -186,6 +194,10 @@ class PostTitleFieldTest extends FormFieldTestCase implements FormFieldTestCaseI
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/ProductCalculationFieldTest.php
+++ b/tests/wpunit/ProductCalculationFieldTest.php
@@ -194,6 +194,10 @@ class ProductCalculationFieldTest extends FormFieldTestCase implements FormField
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -229,6 +233,10 @@ class ProductCalculationFieldTest extends FormFieldTestCase implements FormField
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -258,6 +266,10 @@ class ProductCalculationFieldTest extends FormFieldTestCase implements FormField
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/ProductHiddenFieldTest.php
+++ b/tests/wpunit/ProductHiddenFieldTest.php
@@ -177,6 +177,10 @@ class ProductHiddenFieldTest extends FormFieldTestCase implements FormFieldTestC
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -212,6 +216,10 @@ class ProductHiddenFieldTest extends FormFieldTestCase implements FormFieldTestC
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -241,6 +249,10 @@ class ProductHiddenFieldTest extends FormFieldTestCase implements FormFieldTestC
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/ProductPriceFieldTest.php
+++ b/tests/wpunit/ProductPriceFieldTest.php
@@ -158,6 +158,10 @@ class ProductPriceFieldTest extends FormFieldTestCase implements FormFieldTestCa
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -193,6 +197,10 @@ class ProductPriceFieldTest extends FormFieldTestCase implements FormFieldTestCa
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -222,6 +230,10 @@ class ProductPriceFieldTest extends FormFieldTestCase implements FormFieldTestCa
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/ProductRadioFieldTest.php
+++ b/tests/wpunit/ProductRadioFieldTest.php
@@ -190,6 +190,10 @@ class ProductRadioFieldTest extends FormFieldTestCase implements FormFieldTestCa
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -225,6 +229,10 @@ class ProductRadioFieldTest extends FormFieldTestCase implements FormFieldTestCa
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -254,6 +262,10 @@ class ProductRadioFieldTest extends FormFieldTestCase implements FormFieldTestCa
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/ProductSelectFieldTest.php
+++ b/tests/wpunit/ProductSelectFieldTest.php
@@ -195,6 +195,10 @@ class ProductSelectFieldTest extends FormFieldTestCase implements FormFieldTestC
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -230,6 +234,10 @@ class ProductSelectFieldTest extends FormFieldTestCase implements FormFieldTestC
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -259,6 +267,10 @@ class ProductSelectFieldTest extends FormFieldTestCase implements FormFieldTestC
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/ProductSingleFieldTest.php
+++ b/tests/wpunit/ProductSingleFieldTest.php
@@ -187,6 +187,10 @@ class ProductSingleFieldTest extends FormFieldTestCase implements FormFieldTestC
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -222,6 +226,10 @@ class ProductSingleFieldTest extends FormFieldTestCase implements FormFieldTestC
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -251,6 +259,10 @@ class ProductSingleFieldTest extends FormFieldTestCase implements FormFieldTestC
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/QuantityHiddenFieldTest.php
+++ b/tests/wpunit/QuantityHiddenFieldTest.php
@@ -183,6 +183,10 @@ class QuantityHiddenFieldTest extends FormFieldTestCase implements FormFieldTest
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -214,6 +218,10 @@ class QuantityHiddenFieldTest extends FormFieldTestCase implements FormFieldTest
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -240,6 +248,10 @@ class QuantityHiddenFieldTest extends FormFieldTestCase implements FormFieldTest
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/QuantityNumberFieldTest.php
+++ b/tests/wpunit/QuantityNumberFieldTest.php
@@ -202,6 +202,10 @@ class QuantityNumberFieldTest extends FormFieldTestCase implements FormFieldTest
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -233,6 +237,10 @@ class QuantityNumberFieldTest extends FormFieldTestCase implements FormFieldTest
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -259,6 +267,10 @@ class QuantityNumberFieldTest extends FormFieldTestCase implements FormFieldTest
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/QuantitySelectFieldTest.php
+++ b/tests/wpunit/QuantitySelectFieldTest.php
@@ -233,6 +233,10 @@ class QuantitySelectFieldTest extends FormFieldTestCase implements FormFieldTest
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -264,6 +268,10 @@ class QuantitySelectFieldTest extends FormFieldTestCase implements FormFieldTest
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -290,6 +298,10 @@ class QuantitySelectFieldTest extends FormFieldTestCase implements FormFieldTest
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/QuizCheckboxFieldTest.php
+++ b/tests/wpunit/QuizCheckboxFieldTest.php
@@ -287,6 +287,10 @@ class QuizCheckboxFieldTest extends FormFieldTestCase implements FormFieldTestCa
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -322,6 +326,10 @@ class QuizCheckboxFieldTest extends FormFieldTestCase implements FormFieldTestCa
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -351,6 +359,10 @@ class QuizCheckboxFieldTest extends FormFieldTestCase implements FormFieldTestCa
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/QuizRadioFieldTest.php
+++ b/tests/wpunit/QuizRadioFieldTest.php
@@ -197,6 +197,10 @@ class QuizRadioFieldTest extends FormFieldTestCase implements FormFieldTestCaseI
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -228,6 +232,10 @@ class QuizRadioFieldTest extends FormFieldTestCase implements FormFieldTestCaseI
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -253,6 +261,10 @@ class QuizRadioFieldTest extends FormFieldTestCase implements FormFieldTestCaseI
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/QuizSelectFieldTest.php
+++ b/tests/wpunit/QuizSelectFieldTest.php
@@ -188,6 +188,10 @@ class QuizSelectFieldTest extends FormFieldTestCase implements FormFieldTestCase
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -219,6 +223,10 @@ class QuizSelectFieldTest extends FormFieldTestCase implements FormFieldTestCase
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -244,6 +252,10 @@ class QuizSelectFieldTest extends FormFieldTestCase implements FormFieldTestCase
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/RadioFieldOtherChoiceTest.php
+++ b/tests/wpunit/RadioFieldOtherChoiceTest.php
@@ -142,6 +142,10 @@ class RadioFieldOtherChoice extends FormFieldTestCase implements FormFieldTestCa
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -173,6 +177,10 @@ class RadioFieldOtherChoice extends FormFieldTestCase implements FormFieldTestCa
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -198,6 +206,10 @@ class RadioFieldOtherChoice extends FormFieldTestCase implements FormFieldTestCa
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/RadioFieldTest.php
+++ b/tests/wpunit/RadioFieldTest.php
@@ -135,6 +135,10 @@ class RadioFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -166,6 +170,10 @@ class RadioFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -191,6 +199,10 @@ class RadioFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/SelectFieldTest.php
+++ b/tests/wpunit/SelectFieldTest.php
@@ -140,6 +140,10 @@ class SelectFieldTest extends FormFieldTestCase implements FormFieldTestCaseInte
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -171,6 +175,10 @@ class SelectFieldTest extends FormFieldTestCase implements FormFieldTestCaseInte
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -196,6 +204,10 @@ class SelectFieldTest extends FormFieldTestCase implements FormFieldTestCaseInte
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/ShippingRadioFieldTest.php
+++ b/tests/wpunit/ShippingRadioFieldTest.php
@@ -171,6 +171,10 @@ class ShippingRadioFieldTest extends FormFieldTestCase implements FormFieldTestC
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -202,6 +206,10 @@ class ShippingRadioFieldTest extends FormFieldTestCase implements FormFieldTestC
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -227,6 +235,10 @@ class ShippingRadioFieldTest extends FormFieldTestCase implements FormFieldTestC
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/ShippingSelectFieldTest.php
+++ b/tests/wpunit/ShippingSelectFieldTest.php
@@ -177,6 +177,10 @@ class ShippingSelectFieldTest extends FormFieldTestCase implements FormFieldTest
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -208,6 +212,10 @@ class ShippingSelectFieldTest extends FormFieldTestCase implements FormFieldTest
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -233,6 +241,10 @@ class ShippingSelectFieldTest extends FormFieldTestCase implements FormFieldTest
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/ShippingSingleFieldTest.php
+++ b/tests/wpunit/ShippingSingleFieldTest.php
@@ -127,6 +127,10 @@ class ShippingSingleFieldTest extends FormFieldTestCase implements FormFieldTest
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -158,6 +162,10 @@ class ShippingSingleFieldTest extends FormFieldTestCase implements FormFieldTest
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -183,6 +191,10 @@ class ShippingSingleFieldTest extends FormFieldTestCase implements FormFieldTest
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/SignatureFieldTest.php
+++ b/tests/wpunit/SignatureFieldTest.php
@@ -140,6 +140,10 @@ class SignatureFieldTest extends FormFieldTestCase implements FormFieldTestCaseI
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -171,6 +175,10 @@ class SignatureFieldTest extends FormFieldTestCase implements FormFieldTestCaseI
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -196,6 +204,10 @@ class SignatureFieldTest extends FormFieldTestCase implements FormFieldTestCaseI
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/SubmitDraftEntryMutationTest.php
+++ b/tests/wpunit/SubmitDraftEntryMutationTest.php
@@ -187,6 +187,10 @@ class SubmitDraftEntryMutationTest extends GFGraphQLTestCase {
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					confirmation {
 						message

--- a/tests/wpunit/SubmitFormMutationTest.php
+++ b/tests/wpunit/SubmitFormMutationTest.php
@@ -55,6 +55,8 @@ class SubmitFormMutationTest extends GFGraphQLTestCase {
 		$this->assertCount( 1, $actual['data']['submitGfForm']['errors'] );
 		$this->assertNotEmpty( $actual['data']['submitGfForm']['errors'][0]['id'] );
 		$this->assertNotEmpty( $actual['data']['submitGfForm']['errors'][0]['message'] );
+		$this->assertNotEmpty( $actual['data']['submitGfForm']['errors'][0]['connectedFormField'] );
+		$this->assertEquals( $actual['data']['submitGfForm']['errors'][0]['id'], $actual['data']['submitGfForm']['errors'][0]['connectedFormField']['databaseId'] );
 	}
 
 	public function testSubmitForm(): void {
@@ -827,6 +829,10 @@ class SubmitFormMutationTest extends GFGraphQLTestCase {
 				errors {
 					id
 					message
+					connectedFormField {
+						databaseId
+						type
+					}
 				}
 				resumeUrl
 			}

--- a/tests/wpunit/TextAreaFieldTest.php
+++ b/tests/wpunit/TextAreaFieldTest.php
@@ -133,6 +133,10 @@ class TextAreaFieldTest extends FormFieldTestCase implements FormFieldTestCaseIn
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -164,6 +168,10 @@ class TextAreaFieldTest extends FormFieldTestCase implements FormFieldTestCaseIn
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -189,6 +197,10 @@ class TextAreaFieldTest extends FormFieldTestCase implements FormFieldTestCaseIn
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/TextFieldTest.php
+++ b/tests/wpunit/TextFieldTest.php
@@ -136,6 +136,10 @@ class TextFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -167,6 +171,10 @@ class TextFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -192,6 +200,10 @@ class TextFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/TimeFieldTest.php
+++ b/tests/wpunit/TimeFieldTest.php
@@ -160,6 +160,10 @@ class TimeFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -196,6 +200,10 @@ class TimeFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -226,6 +234,10 @@ class TimeFieldTest extends FormFieldTestCase implements FormFieldTestCaseInterf
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/TotalFieldTest.php
+++ b/tests/wpunit/TotalFieldTest.php
@@ -176,6 +176,10 @@ class TotalFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -210,6 +214,10 @@ class TotalFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -239,6 +247,10 @@ class TotalFieldTest extends FormFieldTestCase implements FormFieldTestCaseInter
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {

--- a/tests/wpunit/WebsiteFieldTest.php
+++ b/tests/wpunit/WebsiteFieldTest.php
@@ -130,6 +130,10 @@ class WebsiteFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -161,6 +165,10 @@ class WebsiteFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry {
 						formFields {
@@ -186,6 +194,10 @@ class WebsiteFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 					errors {
 						id
 						message
+						connectedFormField {
+							databaseId
+							type
+						}
 					}
 					entry: draftEntry {
 						formFields {


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR adds the `connectedFormField` field to the `FieldError` object.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

To provide drill-down information about the error (when necessary).

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

`EntryObjectMutation::get_submission_errors()` has been changed to require the `$form_id` as an argument. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
