### PR TITLE
feat: multi-page form submission improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 - feat!: Implement `FormField` model and `DataLoader`, and refactor `FormFieldsConnectionResolver` to extend `AbstractConnectionResolver`.
 - feat!: Refactor `FormsConnectionResolver` and `EntriesConnectionResolver` for compatibility with WPGraphQL v1.26.0 improvements.
 - feat!: Narrow `FormField.choices` and `FormField.inputs` field types to their implementations.
+- feat: Add `targetPageNumber` and `targetPageFormFields` to `SubmitGfFormPayload` for better multi-page form support.
 - fix!: Keep `PageField` with previous page data when filtering `formFields` by `pageNumber`. H/t @SamuelHadsall .
 - fix: Handle RadioField submission values when using a custom "other" choice. H/t @Gytjarek .
 - fix: Check for Submission Confirmation url before attempting to get the associated post ID.
+- fix: Flush static Gravity Forms state between multiple calls to `GFUtils::submit_form()`. 
 - feat: Add `FieldError.connectedFormField` connection to `FieldError` type.
 - dev: Use `FormFieldsDataLoader` to resolve fields instead of instantiating a new `Model`.
 - chore: Add iterable type hints.
@@ -16,6 +18,7 @@
 - chore!: Bump minimum Gravity Forms version to v2.7.0.
 - chore: Declare `strict_types` in all PHP files.
 - chore: Update Composer dev-dependencies and fix test compatibility with `wp-graphql-test-case` v3.0.x.
+- docs: Add docs on using Multi-page forms.
 
 ## v0.12.6.1
 

--- a/src/Connection/FormFieldsConnection.php
+++ b/src/Connection/FormFieldsConnection.php
@@ -12,7 +12,13 @@ declare( strict_types = 1 );
 
 namespace WPGraphQL\GF\Connection;
 
+use GraphQL\Type\Definition\ResolveInfo;
+use WPGraphQL\AppContext;
+use WPGraphQL\GF\Data\Factory;
+use WPGraphQL\GF\Data\Loader\FormsLoader;
+use WPGraphQL\GF\Mutation\SubmitForm;
 use WPGraphQL\GF\Type\Enum\FormFieldTypeEnum;
+use WPGraphQL\GF\Type\WPInterface\FormField;
 
 /**
  * Class - FormFieldsConnection
@@ -21,15 +27,42 @@ class FormFieldsConnection extends AbstractConnection {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function register_hooks(): void {
-		// @todo register to rootQuery.
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
 	public static function register(): void {
-		// @todo register to rootQuery.
+		// SubmitGfFormPayload to FormFields.
+		register_graphql_connection(
+			[
+				'fromType'      => SubmitForm::$name . 'Payload',
+				'toType'        => FormField::$type,
+				'fromFieldName' => 'targetPageFormFields',
+				'resolve'       => static function ( $source, array $args, AppContext $context, ResolveInfo $info ) {
+					// If the source doesn't have a targetPageNumber, we can't resolve the connection.
+					if ( empty( $source['targetPageNumber'] ) ) {
+						return null;
+					}
+
+					// If the form isn't stored in the context, we need to fetch it.
+					if ( empty( $context->gfForm ) && ! empty( $source['form_id'] ) ) {
+						$form = $context->get_loader( FormsLoader::$name )->load( (int) $source['form_id'] );
+
+						if ( null === $form ) {
+							return null;
+						}
+
+						// Store it in the context for easy access.
+						$context->gfForm = $form;
+					}
+
+					if ( empty( $context->gfForm->formFields ) ) {
+						return null;
+					}
+
+					// Set the Args for the connection resolver.
+					$args['where']['pageNumber'] = $source['targetPageNumber'];
+
+					return Factory::resolve_form_fields_connection( $context->gfForm, $args, $context, $info );
+				},
+			]
+		);
 	}
 
 	/**

--- a/src/Utils/GFUtils.php
+++ b/src/Utils/GFUtils.php
@@ -362,6 +362,11 @@ class GFUtils {
 			$source_page,
 		);
 
+		// Cleanup GF state.
+		unset( $_POST );
+		\GFFormsModel::flush_current_lead();
+		\GFFormDisplay::$submission = [];
+
 		if ( $submission instanceof \WP_Error ) {
 			throw new UserError( esc_html( $submission->get_error_message() ) );
 		}

--- a/tests/_support/Helper/GFHelpers/PropertyHelper.php
+++ b/tests/_support/Helper/GFHelpers/PropertyHelper.php
@@ -232,6 +232,10 @@ class PropertyHelper extends GFHelpers {
 	}
 
 	public function errorMessage( $value = null ) {
+		if ( null === $value ) {
+			return null;
+		}
+
 		return ! empty( $value ) ? $value : 'Some error message';
 	}
 
@@ -267,7 +271,7 @@ class PropertyHelper extends GFHelpers {
 	}
 
 	public function isRequired( $value = null ) {
-		return null !== $value ? $value : false;
+		return null !== $value ? ! empty( $value ) : false;
 	}
 
 	public function isSelected( $value = null ) {

--- a/tests/wpunit/FormFieldConnectionPageFilterTest.php
+++ b/tests/wpunit/FormFieldConnectionPageFilterTest.php
@@ -17,13 +17,11 @@ class FormFieldConnectionPageFilterTest extends GFGraphQLTestCase {
 	private $fields;
 
 	/**
-	 * run before each test.
+	 * {@inheritDoc}
 	 */
 	public function setUp(): void {
 		// Before...
 		parent::setUp();
-
-		wp_set_current_user( $this->admin->ID );
 
 		$this->fields  = $this->generate_form_pages( 3 );
 		$this->form_id = $this->factory->form->create(
@@ -37,7 +35,7 @@ class FormFieldConnectionPageFilterTest extends GFGraphQLTestCase {
 	}
 
 	/**
-	 * Run after each test.
+	 * {@inheritDoc}
 	 */
 	public function tearDown(): void {
 		// Your tear down methods here.

--- a/tests/wpunit/SubmitFormMultipageTest.php
+++ b/tests/wpunit/SubmitFormMultipageTest.php
@@ -1,0 +1,332 @@
+<?php
+/**
+ * Tests submitting a form with multiple pages.
+ */
+
+use Helper\GFHelpers\GFHelpers;
+use Tests\WPGraphQL\GF\TestCase\GFGraphQLTestCase;
+use WPGraphQL\GF\Type\Enum\FormFieldTypeEnum;
+
+/**
+ * Class - SubmitFormMultipageTest
+ */
+class SubmitFormMultipageTest extends GFGraphQLTestCase {
+	private $form_id;
+	private $fields;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		wp_set_current_user( $this->admin->ID );
+
+		$this->fields = $this->generate_form_fields();
+		$this->form_id = $this->factory->form->create(
+			array_merge(
+				[ 'fields' => $this->fields ],
+				$this->tester->getFormDefaultArgs(),
+			)
+		);
+
+		$this->clearSchema();
+	}
+
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function tearDown(): void {
+		// Your tear down methods here.
+		$this->factory->form->delete( $this->form_id );
+
+		// Then...
+		parent::tearDown();
+	}
+
+	private function generate_form_fields(): array {
+		// This will increment as we use them.
+		$id = 1;
+		$page_number = 1;
+
+		return [
+			$this->factory->field->create(
+				array_merge(
+					$this->tester->getPropertyHelper( 'NumberField' )->values,
+					[
+						'id' => $id++,
+						'pageNumber' => $page_number,
+						'isRequired' => true,
+					]
+				)
+			),
+			$this->factory->field->create(
+				array_merge(
+					$this->tester->getPropertyHelper( 'PageField' )->values,
+					[
+						'id'         => $id++,
+						'pageNumber' => ++$page_number,
+						'isRequired' => false,
+						'conditionalLogic' => [
+							'actionType' => 'show',
+							'logicType' => 'all',
+							'rules' => [
+								[
+									'fieldId' => 1,
+									'operator' => 'is',
+									'value' => 2
+								]
+							]
+						]
+					]
+				)
+			),
+			$this->factory->field->create(
+				array_merge(
+					$this->tester->getPropertyHelper( 'NumberField' )->values,
+					[
+						'id' => $id++,
+						'pageNumber' => $page_number,
+						'isRequired' => true,
+					]
+				)
+			),
+			$this->factory->field->create(
+				array_merge(
+					$this->tester->getPropertyHelper( 'PageField' )->values,
+					[
+						'id'         => $id++,
+						'pageNumber' => ++$page_number,
+					]
+				)
+			),
+			$this->factory->field->create(
+				array_merge(
+					$this->tester->getPropertyHelper( 'NumberField' )->values,
+					[
+						'id' => $id++,
+						'pageNumber' => $page_number,
+						'isRequired' => true,
+						'defaultValue' => 'default value',
+					]
+				)
+			)
+		];
+	}
+
+	private function submit_mutation(): string {
+		return '
+			mutation SubmitMultipageForm( $input:SubmitGfFormInput! ) {
+				submitGfForm( input: $input ) {
+					confirmation {
+						type
+					}
+					errors {
+						id
+						message
+						connectedFormField {
+							databaseId
+							type
+						}
+					}
+					entry {
+						... on GfSubmittedEntry {
+							databaseId
+						}
+						... on GfDraftEntry {
+							resumeToken
+						}
+					}
+					targetPageNumber
+					targetPageFormFields {
+						nodes {
+							id
+							databaseId
+							type
+						}
+					}
+				}
+			}
+		';
+	}
+
+	public function testSubmit(): void {
+		$query = $this->submit_mutation();
+
+		$variables = [
+			'input' => [
+				'id'          => $this->form_id,
+				'saveAsDraft' => false,
+			]
+		];
+
+		// Submit the first page with invalid value.
+		$variables['input']['sourcePage'] = 1;
+		$variables['input']['targetPage'] = 2;
+		$variables['input']['fieldValues'] = [];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertResponseIsValid( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNotEmpty( $actual['data']['submitGfForm']['errors'] );
+		$this->assertEquals( 1, $actual['data']['submitGfForm']['targetPageNumber'], 'The target page number should be the invalid page' );
+
+		$this->clear_form_field_state();		
+
+		// On a value that isnt 2, the 3rd page should be the target page.
+		$variables['input']['fieldValues'] = [
+			[
+				'id' => 1,
+				'value' => '0',
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$expected_fields = array_slice( $this->fields, 4, 2, false );
+
+		$this->assertResponseIsValid( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEmpty( $actual['data']['submitGfForm']['errors'] );
+		$this->assertEquals( 3, $actual['data']['submitGfForm']['targetPageNumber'], 'The target page number should be the last page' );
+		$this->assertCount( 1, $actual['data']['submitGfForm']['targetPageFormFields']['nodes'] );
+		$this->assertEquals( $expected_fields[0]['id'], $actual['data']['submitGfForm']['targetPageFormFields']['nodes'][0]['databaseId'] );
+		$this->assertEquals( GFHelpers::get_enum_for_value( FormFieldTypeEnum::$type, $expected_fields[0]['type'] ), $actual['data']['submitGfForm']['targetPageFormFields']['nodes'][0]['type'] );
+
+		// On a 2, the 2nd page should be the target page.
+		$this->clear_form_field_state();
+
+		$variables['input']['fieldValues'] = [
+			[
+				'id' => 1,
+				'value' => '2',
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$expected_fields = array_slice( $this->fields, 2, 2, false );
+
+		$this->assertResponseIsValid( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEmpty( $actual['data']['submitGfForm']['errors'] );
+		$this->assertEquals( 2, $actual['data']['submitGfForm']['targetPageNumber'], 'The target page number should be the 2nd page' );
+		$this->assertCount( 2, $actual['data']['submitGfForm']['targetPageFormFields']['nodes'] );
+		$this->assertEquals( $expected_fields[0]['id'], $actual['data']['submitGfForm']['targetPageFormFields']['nodes'][0]['databaseId'] );
+		$this->assertEquals( GFHelpers::get_enum_for_value( FormFieldTypeEnum::$type, $expected_fields[0]['type'] ), $actual['data']['submitGfForm']['targetPageFormFields']['nodes'][0]['type'] );
+		$this->assertEquals( $expected_fields[1]['id'], $actual['data']['submitGfForm']['targetPageFormFields']['nodes'][1]['databaseId'] );
+		$this->assertEquals( GFHelpers::get_enum_for_value( FormFieldTypeEnum::$type, $expected_fields[1]['type'] ), $actual['data']['submitGfForm']['targetPageFormFields']['nodes'][1]['type'] );
+
+		// Trying to proceed to the 3rd page, should return to the 2nd page.
+		$this->clear_form_field_state();
+
+		$variables['input']['sourcePage'] = 2;
+		$variables['input']['targetPage'] = 3;
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertResponseIsValid( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNotEmpty( $actual['data']['submitGfForm']['errors'] );
+		$this->assertEquals( 2, $actual['data']['submitGfForm']['targetPageNumber'], 'The target page number should be the 2nd page' );
+		$this->assertCount( 2, $actual['data']['submitGfForm']['targetPageFormFields']['nodes'] );
+		$this->assertEquals( $expected_fields[0]['id'], $actual['data']['submitGfForm']['targetPageFormFields']['nodes'][0]['databaseId'] );
+		$this->assertEquals( GFHelpers::get_enum_for_value( FormFieldTypeEnum::$type, $expected_fields[0]['type'] ), $actual['data']['submitGfForm']['targetPageFormFields']['nodes'][0]['type'] );
+		$this->assertEquals( $expected_fields[1]['id'], $actual['data']['submitGfForm']['targetPageFormFields']['nodes'][1]['databaseId'] );
+		$this->assertEquals( GFHelpers::get_enum_for_value( FormFieldTypeEnum::$type, $expected_fields[1]['type'] ), $actual['data']['submitGfForm']['targetPageFormFields']['nodes'][1]['type'] );
+
+		// With the correct value, the 3rd page should be the target page.
+		$this->clear_form_field_state();
+
+		$variables['input']['fieldValues'] = array_merge(
+			$variables['input']['fieldValues'],
+			[
+				[
+					'id' => 3,
+					'value' => '2',
+				],
+			]
+		);
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$expected_fields = array_slice( $this->fields, 4, 2, false );
+
+		$this->assertResponseIsValid( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEmpty( $actual['data']['submitGfForm']['errors'] );
+		$this->assertEquals( 3, $actual['data']['submitGfForm']['targetPageNumber'], 'The target page number should be the 3nd page' );
+		$this->assertCount( 1, $actual['data']['submitGfForm']['targetPageFormFields']['nodes'] );
+		$this->assertEquals( $expected_fields[0]['id'], $actual['data']['submitGfForm']['targetPageFormFields']['nodes'][0]['databaseId'] );
+		$this->assertEquals( GFHelpers::get_enum_for_value( FormFieldTypeEnum::$type, $expected_fields[0]['type'] ), $actual['data']['submitGfForm']['targetPageFormFields']['nodes'][0]['type'] );
+
+		// Test a target after our last page.
+		$this->clear_form_field_state();
+
+		$variables['input']['targetPage'] = 4;
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertResponseIsValid( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNotEmpty( $actual['data']['submitGfForm']['errors'] );
+		$this->assertEquals( 3, $actual['data']['submitGfForm']['targetPageNumber'], 'The target page number should be the 3nd page' );
+		$this->assertCount( 1, $actual['data']['submitGfForm']['targetPageFormFields']['nodes'] );
+		$this->assertEquals( $expected_fields[0]['id'], $actual['data']['submitGfForm']['targetPageFormFields']['nodes'][0]['databaseId'] );
+		$this->assertEquals( GFHelpers::get_enum_for_value( FormFieldTypeEnum::$type, $expected_fields[0]['type'] ), $actual['data']['submitGfForm']['targetPageFormFields']['nodes'][0]['type'] );
+
+		// Test with the required values.
+		$this->clear_form_field_state();
+
+		$variables['input']['fieldValues'] = array_merge(
+			$variables['input']['fieldValues'],
+			[
+				[
+					'id' => 5,
+					'value' => '1',
+				],
+			]
+		);
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertResponseIsValid( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEmpty( $actual['data']['submitGfForm']['errors'] );
+		$this->assertNotEmpty( $actual['data']['submitGfForm']['entry']['databaseId'] );
+		$this->assertNull( $actual['data']['submitGfForm']['targetPageNumber'] );
+		$this->assertEmpty( $actual['data']['submitGfForm']['targetPageFormFields'] );
+
+
+		// Test as Draft.
+		$this->clear_form_field_state();
+
+		$variables['input']['saveAsDraft'] = true;
+		$variables['input']['fieldValues'] = [];
+		$variables['input']['sourcePage'] = 1;
+		$variables['input']['targetPage'] = 3;
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertResponseIsValid( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEmpty( $actual['data']['submitGfForm']['errors'] );
+		$this->assertEquals( 3, $actual['data']['submitGfForm']['targetPageNumber'], 'The target page number should be the 3nd page' );
+		$this->assertCount( 1, $actual['data']['submitGfForm']['targetPageFormFields']['nodes'] );
+		$this->assertEquals( $expected_fields[0]['id'], $actual['data']['submitGfForm']['targetPageFormFields']['nodes'][0]['databaseId'] );
+		$this->assertEquals( GFHelpers::get_enum_for_value( FormFieldTypeEnum::$type, $expected_fields[0]['type'] ), $actual['data']['submitGfForm']['targetPageFormFields']['nodes'][0]['type'] );
+	}
+
+	/**
+	 * Clears the form field state.
+	 */
+	private function clear_form_field_state(): void {
+		$form = GFAPI::get_form( $this->form_id );
+
+		foreach( $form['fields'] as $field ) {
+			unset( $field->failed_validation );
+			unset( $field->validation_message );
+		}
+	}
+}


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR:
- fixes and issue where the GF state wasnt getting flushed if multiple `GFUtils::submit_form()` calls are made.
- adds the `targetPageNumber` (int) and `targetPageFormFields` (Form Field connection) to `SubmitGfFormPayload` for better multi-page form support.
- Backfills tests for `sourcePage` and `targetPage`.
- Adds docs for submitting multi-page forms.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
Fixes #208

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
