### PR TITLE
dev: use WP_Filesystem for Signature Field uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - feat: Add support for WPGraphQL Content Blocks.
 - dev: Remove `vendor` directory from the GitHub repository.
 - dev: Use `FormFieldsDataLoader` to resolve fields instead of instantiating a new `Model`.
+- dev: use WP_Filesystem to handle Signature field uploads.
 - chore!: Remove deprecated fields from the schema: `FormsConnectionOrderbyInput.field`, `GfFieldWithDisableQuantitySetting.isQuantityDisabled`. `GfSubmittedEntry.entryId`. `GfForm.button`, `gfForm.entryId`, `gfForm.lastPageButton`.
 - chore!: Remove deprecated hooks: `graphql_gf_form_modeled_data_experimental`, `graphql_gf_form_field_setting_properties`, `graphql_gf_form_field_value_properties`.
 - chore!: Remove deprecated helper method: `GFUtils::handle_file_upload()`.

--- a/src/Extensions/GFSignature/Data/FieldValueInput/SignatureValuesInput.php
+++ b/src/Extensions/GFSignature/Data/FieldValueInput/SignatureValuesInput.php
@@ -88,8 +88,16 @@ class SignatureValuesInput extends ValueInput {
 		$folder   = \GFSignature::get_signatures_folder();
 		$filename = uniqid( '', true ) . '.png';
 		$path     = $folder . $filename;
-		// @todo: switch to WP Filesystem.
-		$number_of_bytes = file_put_contents( $path, $signature_decoded ); //phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents, WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents
+
+		// Use WP_Filesystem to save the signature image.
+		global $wp_filesystem;
+		if ( ! $wp_filesystem instanceof \WP_Filesystem_Base ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+			WP_Filesystem();
+		}
+
+		/** @var \WP_Filesystem_Base $wp_filesystem */
+		$number_of_bytes = $wp_filesystem->put_contents( $path, $signature_decoded, FS_CHMOD_FILE );
 
 		if ( false === $number_of_bytes ) {
 			throw new UserError( esc_html__( 'An error occurred while saving the signature image.', 'wp-graphql-gravity-forms' ) );


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR changes Signature uploading to use `\WP_Filesystem` instead of `file_put_contents()`

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

Compliance with wpcs/pcp

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
