### PR TITLE
feat: Replace `GfFieldWithProductFieldSetting.productField` with  `.connectedProductField`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - fix: Add missing descriptions to types.
 - feat: Add `FieldError.connectedFormField` connection to `FieldError` type.
 - feat: Add support for WPGraphQL Content Blocks.
+- feat: Add `GfFieldWithProductFieldSetting.connectedProductField` connection and deprecate `.productField` field.
 - dev: Remove `vendor` directory from the GitHub repository.
 - dev: Use `FormFieldsDataLoader` to resolve fields instead of instantiating a new `Model`.
 - dev: use WP_Filesystem to handle Signature field uploads.

--- a/src/Registry/FormFieldRegistry.php
+++ b/src/Registry/FormFieldRegistry.php
@@ -161,8 +161,10 @@ class FormFieldRegistry {
 
 				$config['resolveType'] = static function ( $value ) use ( $type_registry, $possible_types ) {
 					$input_type = $value->get_input_type();
+
 					if ( isset( $possible_types[ $input_type ] ) ) {
-						$type = $type_registry->get_type( $possible_types[ $value->$input_type ] );
+						$type = $type_registry->get_type( $possible_types[ $input_type ] );
+
 						if ( null !== $type ) {
 							return $type;
 						}
@@ -173,7 +175,7 @@ class FormFieldRegistry {
 						/* translators: %s: GF field type */
 							esc_html__( 'The "%1$1s" Gravity Forms field does not yet support the %2$2s input type.', 'wp-graphql-gravity-forms' ),
 							esc_html( $value->type ),
-							esc_html( $value->inputType ),
+							esc_html( $input_type ?? $value->inputType ),
 						)
 					);
 				};

--- a/src/Type/WPInterface/FieldSetting/FieldWithProductField.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithProductField.php
@@ -10,6 +10,9 @@ declare( strict_types = 1 );
 
 namespace WPGraphQL\GF\Type\WPInterface\FieldSetting;
 
+use WPGraphQL\AppContext;
+use WPGraphQL\GF\Data\Loader\FormFieldsLoader;
+
 /**
  * Class - FieldWithProductField
  */
@@ -34,9 +37,23 @@ class FieldWithProductField extends AbstractFieldSetting {
 	public static function get_fields(): array {
 		// @todo make connection.
 		return [
-			'productField' => [
-				'type'        => 'Int',
-				'description' => __( 'The id of the product field to which the field is associated.', 'wp-graphql-gravity-forms' ),
+			'productField'          => [
+				'type'              => 'Int',
+				'description'       => __( 'The id of the product field to which the field is associated.', 'wp-graphql-gravity-forms' ),
+				'deprecationReason' => __( 'Use `connectedProductField` field instead.', 'wp-graphql-gravity-forms' ),
+			],
+			'connectedProductField' => [
+				'type'        => 'ProductField',
+				'description' => __( 'The product field to which the field is associated.', 'wp-graphql-gravity-forms' ),
+				'resolve'     => static function ( $source, array $args, AppContext $context ) {
+					if ( ! isset( $context->gfForm ) || empty( $source->productField ) ) {
+						return null;
+					}
+
+					$id_for_loader = FormFieldsLoader::prepare_loader_id( $context->gfForm->databaseId, (int) $source->productField );
+
+					return $context->get_loader( FormFieldsLoader::$name )->load_deferred( $id_for_loader );
+				},
 			],
 		];
 	}

--- a/src/Type/WPInterface/FieldSetting/FieldWithProductField.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithProductField.php
@@ -35,7 +35,6 @@ class FieldWithProductField extends AbstractFieldSetting {
 	 * {@inheritDoc}
 	 */
 	public static function get_fields(): array {
-		// @todo make connection.
 		return [
 			'productField'          => [
 				'type'              => 'Int',

--- a/tests/wpunit/OptionCheckboxFieldTest.php
+++ b/tests/wpunit/OptionCheckboxFieldTest.php
@@ -294,7 +294,10 @@ class OptionCheckboxFieldTest extends FormFieldTestCase implements FormFieldTest
 					shouldExport
 				}
 				placeholder
-				productField
+				connectedProductField {
+					databaseId
+					type
+				}
 				type
 				... on OptionCheckboxField {
 					checkboxValues {

--- a/tests/wpunit/OptionRadioFieldTest.php
+++ b/tests/wpunit/OptionRadioFieldTest.php
@@ -177,7 +177,10 @@ class OptionRadioFieldTest extends FormFieldTestCase implements FormFieldTestCas
 					shouldExport
 				}
 				placeholder
-				productField
+				connectedProductField {
+					databaseId
+					type
+				}
 				type
 				... on OptionRadioField {
 					hasOtherChoice

--- a/tests/wpunit/OptionSelectFieldTest.php
+++ b/tests/wpunit/OptionSelectFieldTest.php
@@ -184,7 +184,10 @@ class OptionSelectFieldTest extends FormFieldTestCase implements FormFieldTestCa
 					shouldExport
 				}
 				placeholder
-				productField
+				connectedProductField {
+					databaseId
+					type
+				}
 				type
 				... on OptionSelectField {
 					autocompleteAttribute

--- a/tests/wpunit/QuantityHiddenFieldTest.php
+++ b/tests/wpunit/QuantityHiddenFieldTest.php
@@ -164,7 +164,10 @@ class QuantityHiddenFieldTest extends FormFieldTestCase implements FormFieldTest
 					shouldExport
 				}
 				placeholder
-				productField
+				connectedProductField {
+					databaseId
+					type
+				}
 				type
 				... on QuantityHiddenField {
 					value

--- a/tests/wpunit/QuantityNumberFieldTest.php
+++ b/tests/wpunit/QuantityNumberFieldTest.php
@@ -171,7 +171,10 @@ class QuantityNumberFieldTest extends FormFieldTestCase implements FormFieldTest
 					shouldExport
 				}
 				placeholder
-				productField
+				connectedProductField {
+					databaseId
+					type
+				}
 				type
 				value
 				... on QuantityNumberField {

--- a/tests/wpunit/QuantitySelectFieldTest.php
+++ b/tests/wpunit/QuantitySelectFieldTest.php
@@ -199,7 +199,10 @@ class QuantitySelectFieldTest extends FormFieldTestCase implements FormFieldTest
 					shouldExport
 				}
 				placeholder
-				productField
+				connectedProductField {
+					databaseId
+					type
+				}
 				type
 				value
 				... on QuantitySelectField {


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
This PR deprecates the (int) `GfFieldWithProductFieldSetting.productField` in favor of (ProductField) `.connectedProductField`.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
